### PR TITLE
Fix re-finalize crowning the re-evaluated miner instead of re-ranking…

### DIFF
--- a/tests/validator/scoring/test_refinalize_reranks.py
+++ b/tests/validator/scoring/test_refinalize_reranks.py
@@ -1,0 +1,97 @@
+"""Re-finalizing a task must re-rank every valid miner, not just freshly evaluated ones.
+
+Regression cover for the bug where `calculate_miner_ranking_and_scores` skips any result that
+already carries a `score_reason`, combined with `_result_from_persisted_row` carrying the previous
+ranking reason forward. On a partial re-evaluation + re-finalize that crowned whichever hotkey was
+re-evaluated (its reason had been cleared), regardless of its actual loss.
+"""
+
+from types import SimpleNamespace
+
+from core.models.task_models import TaskType
+from validator.scoring import constants as scoring_cst
+from validator.scoring.tasks import BOTTOM_PENALTY_REASON_PREFIX
+from validator.scoring.tasks import RANKED_BELOW_REASON_PREFIX
+from validator.scoring.tasks import RANKED_FIRST_REASON_PREFIX
+from validator.scoring.tasks import _is_ranking_derived_reason
+from validator.scoring.tasks import _result_from_persisted_row
+from validator.scoring.tasks import calculate_miner_ranking_and_scores
+
+
+def _image_task():
+    return SimpleNamespace(task_type=TaskType.IMAGETASK, task_id=None)
+
+
+def _row(test_loss, score_reason):
+    return {"test_loss": test_loss, "synth_loss": test_loss, "score_reason": score_reason}
+
+
+class TestIsRankingDerivedReason:
+    def test_ranking_reasons_match(self) -> None:
+        assert _is_ranking_derived_reason(f"{RANKED_FIRST_REASON_PREFIX}test_loss")
+        assert _is_ranking_derived_reason(f"{RANKED_BELOW_REASON_PREFIX}test_loss")
+        assert _is_ranking_derived_reason(f"{BOTTOM_PENALTY_REASON_PREFIX}test_loss")
+
+    def test_failure_and_empty_reasons_do_not_match(self) -> None:
+        assert not _is_ranking_derived_reason(None)
+        assert not _is_ranking_derived_reason("")
+        assert not _is_ranking_derived_reason("Non-finetuned submission")
+        assert not _is_ranking_derived_reason("Evaluation failed: boom")
+        assert not _is_ranking_derived_reason("Invalid test loss")
+
+
+class TestResultFromPersistedRow:
+    def test_ranking_reason_is_dropped_for_valid_loss(self) -> None:
+        result = _result_from_persisted_row(
+            _image_task(), "hk", _row(0.03, f"{RANKED_FIRST_REASON_PREFIX}test_loss")
+        )
+        assert result.score_reason is None
+        assert result.is_finetune is True
+        assert result.test_loss == 0.03
+
+    def test_exclusion_reason_is_preserved_for_valid_loss(self) -> None:
+        result = _result_from_persisted_row(_image_task(), "hk", _row(0.0, "Non-finetuned submission"))
+        assert result.score_reason == "Non-finetuned submission"
+
+    def test_missing_loss_stays_failed(self) -> None:
+        result = _result_from_persisted_row(_image_task(), "hk", _row(None, "Evaluation failed: boom"))
+        assert result.is_finetune is False
+        assert result.score_reason == "Evaluation failed: boom"
+
+
+class TestReFinalizeReranksAll:
+    def test_lowest_loss_wins_after_refinalize(self) -> None:
+        # Simulate re-finalize: every miner already carries a persisted ranking reason from a prior
+        # finalize, and the mid-pack miner "cleared" was just re-evaluated (reason back to None).
+        persisted = {
+            "best": _row(0.010, f"{RANKED_FIRST_REASON_PREFIX}test_loss"),
+            "second": _row(0.020, f"{RANKED_BELOW_REASON_PREFIX}test_loss"),
+            "cleared": _row(0.030, None),
+            "worst": _row(0.040, f"{RANKED_BELOW_REASON_PREFIX}test_loss"),
+        }
+        task = _image_task()
+        results = [_result_from_persisted_row(task, hk, row) for hk, row in persisted.items()]
+
+        scored = {r.hotkey: r for r in calculate_miner_ranking_and_scores(results)}
+
+        assert scored["best"].score == scoring_cst.FIRST_PLACE_SCORE
+        assert scored["best"].score_reason == f"{RANKED_FIRST_REASON_PREFIX}test_loss"
+        # The re-evaluated mid-pack miner must NOT be crowned just because its reason was cleared.
+        assert scored["cleared"].score != scoring_cst.FIRST_PLACE_SCORE
+        assert scored["cleared"].score_reason == f"{RANKED_BELOW_REASON_PREFIX}test_loss"
+
+    def test_non_finetune_stays_excluded_after_refinalize(self) -> None:
+        # A base-model (non-finetune) submission can have a very low loss but must never win; its
+        # exclusion reason is preserved on reload, so it is skipped by the ranking.
+        persisted = {
+            "real_winner": _row(0.050, f"{RANKED_FIRST_REASON_PREFIX}test_loss"),
+            "base_model": _row(0.000, "Non-finetuned submission"),
+        }
+        task = _image_task()
+        results = [_result_from_persisted_row(task, hk, row) for hk, row in persisted.items()]
+
+        scored = {r.hotkey: r for r in calculate_miner_ranking_and_scores(results)}
+
+        assert scored["real_winner"].score == scoring_cst.FIRST_PLACE_SCORE
+        assert scored["base_model"].score != scoring_cst.FIRST_PLACE_SCORE
+        assert scored["base_model"].score_reason == "Non-finetuned submission"

--- a/validator/scoring/tasks.py
+++ b/validator/scoring/tasks.py
@@ -84,6 +84,29 @@ class PvPEvaluationExhaustedError(RuntimeError):
         self.deployment_ids = deployment_ids or []
 
 
+# Score reasons produced by ranking below. Unlike failure/exclusion reasons (e.g. "Evaluation
+# failed", "Non-finetuned submission"), these are recomputed on every finalize from the current
+# pool, so they must not be treated as pre-set reasons when rebuilding results from persisted rows.
+RANKED_FIRST_REASON_PREFIX = "Ranked 1st by "
+RANKED_BELOW_REASON_PREFIX = "Ranked below top 1 by "
+BOTTOM_PENALTY_REASON_PREFIX = "Bottom 25% ranked by "
+
+
+def _is_ranking_derived_reason(reason: str | None) -> bool:
+    """True for score reasons assigned by calculate_miner_ranking_and_scores from the ranking.
+
+    These reasons encode a prior ranking, not an intrinsic reason to exclude a miner. When a task is
+    re-finalized (e.g. after re-evaluating one hotkey), rebuilding results must drop these so every
+    valid miner re-enters the ranking pool. Otherwise calculate_miner_ranking_and_scores skips every
+    already-scored miner and crowns whichever hotkey was freshly evaluated.
+    """
+    if not reason:
+        return False
+    return reason.startswith(
+        (RANKED_FIRST_REASON_PREFIX, RANKED_BELOW_REASON_PREFIX, BOTTOM_PENALTY_REASON_PREFIX)
+    )
+
+
 def calculate_miner_ranking_and_scores(
     miner_results: list[MinerResultsText | MinerResultsImage],
 ) -> list[MinerResultsText | MinerResultsImage]:
@@ -151,7 +174,7 @@ def calculate_miner_ranking_and_scores(
         top_result, top_metric = ranked_results[0]
         with LogContext(miner_hotkey=top_result.hotkey):
             top_result.score = scoring_cst.FIRST_PLACE_SCORE
-            top_result.score_reason = f"Ranked 1st by {ranking_type}"
+            top_result.score_reason = f"{RANKED_FIRST_REASON_PREFIX}{ranking_type}"
             logger.info(
                 f"Miner {top_result.hotkey} (finetuned):"
                 f" test_loss={top_result.test_loss:.4f}"
@@ -167,7 +190,7 @@ def calculate_miner_ranking_and_scores(
 
         for result, metric in ranked_results[1:penalty_start_idx]:
             with LogContext(miner_hotkey=result.hotkey):
-                result.score_reason = f"Ranked below top 1 by {ranking_type}"
+                result.score_reason = f"{RANKED_BELOW_REASON_PREFIX}{ranking_type}"
                 logger.info(
                     f"Miner {result.hotkey} (finetuned):"
                     f" test_loss={result.test_loss:.4f}"
@@ -179,7 +202,7 @@ def calculate_miner_ranking_and_scores(
         for result, metric in ranked_results[penalty_start_idx:]:
             with LogContext(miner_hotkey=result.hotkey):
                 result.score = scoring_cst.SCORE_PENALTY
-                result.score_reason = f"Bottom 25% ranked by {ranking_type}"
+                result.score_reason = f"{BOTTOM_PENALTY_REASON_PREFIX}{ranking_type}"
                 logger.info(
                     f"Miner {result.hotkey} (finetuned):"
                     f" test_loss={result.test_loss:.4f}"
@@ -190,7 +213,7 @@ def calculate_miner_ranking_and_scores(
     else:
         for result, metric in ranked_results[1:]:
             with LogContext(miner_hotkey=result.hotkey):
-                result.score_reason = f"Ranked below top 1 by {ranking_type}"
+                result.score_reason = f"{RANKED_BELOW_REASON_PREFIX}{ranking_type}"
                 logger.info(
                     f"Miner {result.hotkey} (finetuned):"
                     f" test_loss={result.test_loss:.4f}"
@@ -505,13 +528,18 @@ def _result_from_persisted_row(task: AnyTypeRawTask, hotkey: str, row: dict | No
             task_type=task.task_type,
         )
 
+    # Drop reasons that merely encode a prior ranking so this valid submission re-enters the pool on
+    # re-finalize. Genuine exclusion reasons (e.g. "Non-finetuned submission") are preserved because
+    # calculate_miner_ranking_and_scores keys off score_reason to keep such rows out of the ranking.
+    reason_for_ranking = None if _is_ranking_derived_reason(score_reason) else score_reason
+
     if task.task_type == TaskType.IMAGETASK:
         return MinerResultsImage(
             hotkey=hotkey,
             test_loss=float(test_loss),
             synth_loss=float(synth_loss),
             is_finetune=True,
-            score_reason=score_reason,
+            score_reason=reason_for_ranking,
         )
 
     return MinerResultsText(
@@ -519,7 +547,7 @@ def _result_from_persisted_row(task: AnyTypeRawTask, hotkey: str, row: dict | No
         test_loss=float(test_loss),
         synth_loss=float(synth_loss),
         is_finetune=True,
-        score_reason=score_reason,
+        score_reason=reason_for_ranking,
         task_type=task.task_type,
     )
 


### PR DESCRIPTION
… all

calculate_miner_ranking_and_scores skips any result that already has a score_reason (to keep failed/non-finetune submissions out of the ranking), and _result_from_persisted_row carried the previously persisted ranking reason forward. So re-finalizing a task after re-evaluating a subset of hotkeys left only the freshly evaluated miners (whose reason had been cleared) in the ranking pool, crowning one of them 1st regardless of its actual loss and demoting the true winner.

Strip only ranking-derived reasons ("Ranked 1st ...", "Ranked below top 1 ...", "Bottom 25% ...") when rebuilding persisted rows, so every valid submission re-enters ranking on re-finalize. Genuine exclusion reasons (e.g. "Non-finetuned submission", "Evaluation failed ...") are preserved, since the persisted path loses is_finetune and relies on score_reason to keep those rows out. The ranking reason strings are centralized as constants so production and detection stay in sync. Adds focused regression tests.