### PR TITLE
Skip TRL reference model in GRPO eval to avoid full-model OOM.

### DIFF
--- a/validator/evaluation/evaluators/grpo.py
+++ b/validator/evaluation/evaluators/grpo.py
@@ -211,7 +211,7 @@ def evaluate_grpo_model(
             per_device_eval_batch_size=batch_size,
             report_to="none",
             bf16=True,
-            beta=cst.BETA_GRPO,
+            beta=0.0,
             num_generations=num_generations,
         )
         grpo_trainer = GRPOTrainer(


### PR DESCRIPTION
Set eval-time GRPOConfig beta to 0 so generation and reward capture still run while the KL penalty continues to come from single_kl_divergence and BETA_GRPO in result_processing.