### PR TITLE
Add unit tests for get_base_contestant to validate dataset propagatio…

### DIFF
--- a/tests/validator/tournament/test_base_contestant_datasets.py
+++ b/tests/validator/tournament/test_base_contestant_datasets.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+from core.models.tournament_models import TournamentType
+from validator.scoring.constants import EMISSION_BURN_HOTKEY
+from validator.tournament.participants import get_base_contestant
+
+
+MODULE = "validator.tournament.participants"
+ENVIRONMENT = TournamentType.ENVIRONMENT
+
+
+def _winner(**kwargs):
+    return SimpleNamespace(
+        tournament_id=kwargs.get("tournament_id", "tourn_prev"),
+        hotkey=kwargs.get("hotkey", "5WinnerHotkey"),
+        training_repo=kwargs.get("training_repo"),
+        backup_repo=kwargs.get("backup_repo"),
+        training_commit_hash=kwargs.get("training_commit_hash"),
+        requested_datasets=kwargs.get("requested_datasets"),
+    )
+
+
+class TestGetBaseContestant:
+    @pytest.mark.asyncio
+    async def test_propagates_previous_winner_datasets(self):
+        latest_winner = _winner(
+            backup_repo="https://github.com/gradients-opensource/god-environment-position-1.git",
+            training_commit_hash="abc123",
+            requested_datasets=[
+                "gradients-io-tournaments/pvp-tool-calling-sft",
+                "gradients-io-tournaments/SWE-ZERO-12M-trajectories-filtered",
+            ],
+        )
+
+        with (
+            patch(f"{MODULE}.get_latest_tournament_winner_participant", new_callable=AsyncMock) as winner_lookup,
+            patch(f"{MODULE}.get_latest_commit_hash_from_github", new_callable=AsyncMock) as commit_lookup,
+        ):
+            winner_lookup.return_value = latest_winner
+            commit_lookup.return_value = "deadbeef"
+
+            base = await get_base_contestant(AsyncMock(), ENVIRONMENT, AsyncMock())
+
+        assert base is not None
+        assert base.hotkey == EMISSION_BURN_HOTKEY
+        assert base.training_repo == latest_winner.backup_repo
+        assert base.requested_datasets == [
+            "gradients-io-tournaments/pvp-tool-calling-sft",
+            "gradients-io-tournaments/SWE-ZERO-12M-trajectories-filtered",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_datasets_when_previous_winner_has_none(self):
+        latest_winner = _winner(
+            backup_repo="https://github.com/gradients-opensource/god-environment-position-1.git",
+            training_commit_hash="abc123",
+        )
+
+        with (
+            patch(f"{MODULE}.get_latest_tournament_winner_participant", new_callable=AsyncMock) as winner_lookup,
+            patch(f"{MODULE}.get_latest_commit_hash_from_github", new_callable=AsyncMock) as commit_lookup,
+        ):
+            winner_lookup.return_value = latest_winner
+            commit_lookup.return_value = "deadbeef"
+
+            base = await get_base_contestant(AsyncMock(), ENVIRONMENT, AsyncMock())
+
+        assert base is not None
+        assert base.requested_datasets is None

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -185,8 +185,9 @@ async def add_tournament_participants(participants: list[TournamentParticipant],
         async with connection.transaction():
             query = f"""
                 INSERT INTO {cst.TOURNAMENT_PARTICIPANTS_TABLE}
-                ({cst.TOURNAMENT_ID}, {cst.HOTKEY}, {cst.TRAINING_REPO}, {cst.TRAINING_COMMIT_HASH}, {cst.CREATED_AT})
-                VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)
+                ({cst.TOURNAMENT_ID}, {cst.HOTKEY}, {cst.TRAINING_REPO}, {cst.TRAINING_COMMIT_HASH},
+                 {cst.REQUESTED_DATASETS}, {cst.CREATED_AT})
+                VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
                 ON CONFLICT ({cst.TOURNAMENT_ID}, {cst.HOTKEY}) DO NOTHING
             """
             for participant in participants:
@@ -196,6 +197,7 @@ async def add_tournament_participants(participants: list[TournamentParticipant],
                     participant.hotkey,
                     participant.training_repo,
                     participant.training_commit_hash,
+                    json.dumps(participant.requested_datasets) if participant.requested_datasets else None,
                 )
             logger.info(f"Added {len(participants)} participants to tournament")
 

--- a/validator/tournament/participants.py
+++ b/validator/tournament/participants.py
@@ -1,12 +1,13 @@
 import aiohttp
 
+from core.datasets.whitelist import validate_requested_datasets
 from core.logging import get_logger
+from validator.app.config import Config
 from validator.db.database import PSQLDB
 from validator.db.sql.tournaments import get_latest_completed_tournament
 from validator.db.sql.tournaments import get_tournament_pairs
 from validator.db.sql.tournaments import get_tournament_participant
 from validator.scoring.constants import EMISSION_BURN_HOTKEY
-from validator.app.config import Config
 from validator.tournament.constants import DEFAULT_PARTICIPANT_COMMIT
 from validator.tournament.constants import DEFAULT_PARTICIPANT_REPO
 from validator.tournament.models import RoundType
@@ -79,6 +80,9 @@ async def get_base_contestant(psql_db: PSQLDB, tournament_type: TournamentType, 
     latest_winner = await get_latest_tournament_winner_participant(psql_db, tournament_type, config)
     if latest_winner:
         logger.info(f"Using latest tournament winner as BASE: {latest_winner.hotkey}")
+        requested_datasets = validate_requested_datasets(latest_winner.requested_datasets) or None
+        if requested_datasets:
+            logger.info(f"Base contestant requested datasets: {requested_datasets}")
 
         if latest_winner.backup_repo:
             logger.info(f"Previous winner has backup repo: {latest_winner.backup_repo}")
@@ -91,6 +95,7 @@ async def get_base_contestant(psql_db: PSQLDB, tournament_type: TournamentType, 
                 hotkey=EMISSION_BURN_HOTKEY,
                 training_repo=latest_winner.backup_repo,
                 training_commit_hash=commit_hash,
+                requested_datasets=requested_datasets,
             )
         else:
             logger.warning("Could not determine tournament ID for uploaded repo, falling back to original training_repo")
@@ -100,6 +105,7 @@ async def get_base_contestant(psql_db: PSQLDB, tournament_type: TournamentType, 
                 hotkey=EMISSION_BURN_HOTKEY,
                 training_repo=latest_winner.training_repo,
                 training_commit_hash=latest_winner.training_commit_hash,
+                requested_datasets=requested_datasets,
             )
 
     logger.info(

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -865,6 +865,7 @@ async def create_basic_tournament(tournament_type: TournamentType, psql_db: PSQL
             hotkey=base_contestant.hotkey,  # This will be EMISSION_BURN_HOTKEY
             training_repo=base_contestant.training_repo,
             training_commit_hash=base_contestant.training_commit_hash,
+            requested_datasets=base_contestant.requested_datasets,
         )
         await add_tournament_participants([base_participant], psql_db)
 


### PR DESCRIPTION
…n and handling of empty datasets

- Introduced a new test file for tournament participant validation.
- Added tests to ensure that the previous winner's datasets are correctly propagated to the base contestant.
- Implemented a check for scenarios where the previous winner has no datasets, ensuring the base contestant handles this case appropriately.
- Updated the database schema to include requested datasets for tournament participants.
- Enhanced the get_base_contestant function to validate and log requested datasets.