### PR TITLE
Rebase continuous text lineage and promote SWE target model base.

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -411,7 +411,7 @@ Text tournaments use `InstructTextTask`, `DpoTask`, and `GrpoTask`.
 - Knockout pairs receive one task, selected probabilistically from instruct, DPO, and GRPO.
 - **Knockout instruct, DPO and chat tasks are decided per held-out sample, not on mean loss.** Both submissions are scored on the identical held-out set, and the winner is whichever won more individual samples. A sample counts for neither side when the two losses are within `BOSS_ROUND_TIE_DEADZONE_NATS` (0.01 nats) of each other. If the sample wins are equal, or every sample falls inside that dead zone, the lower mean loss decides. The sample winner must also not be worse on the ranking loss — winning a majority of samples by a hair while losing the rest badly does not advance, and on KL-weighted tasks (every knockout instruct task from round 2) the per-sample comparison uses raw cross-entropy while the ranking loss carries the KL penalty. GRPO knockout tasks still rank on the mean score.
 - The knockout round before the boss round (the last pair, whose winner becomes the boss challenger) always plays a single instruct task on a forced model: `PRE_BOSS_MODEL` (currently `Qwen/Qwen3-32B`), with augmentation, KL and YaRN disabled so both competitors train the exact published model.
-- The final boss round creates 5 tasks: 2 instruct, 1 DPO, 1 GRPO, and one continuous-SFT chat task per lineage (currently 1: `qwen`). Each continuous-SFT lineage carries across tournaments — every round trains the next chunk starting from that lineage's previous winner (or a fixed seed model on the first run). Some final tasks may use larger models.
+- The final boss round creates 5 tasks: 2 instruct, 1 DPO, 1 GRPO, and one continuous-SFT chat task per lineage (currently 1: `qwen3-14b`). Each continuous-SFT lineage carries across tournaments — every round trains the next chunk starting from that lineage's previous winner (or a fixed seed model on the first run). Some final tasks may use larger models.
 - **Boss-round instruct, DPO and continuous-SFT (chat) tasks are decided per held-out sample.** Both models are scored on the identical held-out set and compared sample by sample. To take a task the challenger must clear **both** of:
   - win at least `BOSS_ROUND_MIN_WIN_RATE` (55%) of *decided* samples — those where the two losses differ by more than the `BOSS_ROUND_TIE_DEADZONE_NATS` (0.01 nats) dead zone; and
   - be ahead on the mean by at least `max(BOSS_ROUND_MIN_MEAN_GAP_NATS, BOSS_ROUND_WIN_MARGIN x boss mean loss)` — a floor of 0.01 nats, the same value as the tie dead zone, that scales to 1% of the loss above a boss loss of 1.0 so it is never a weaker requirement than the old margin.
@@ -571,7 +571,7 @@ validator database access:
 ```bash
 uv run --extra dev python -m ops.tools.evaluation.local_swe_infinite_eval \
   --model YOUR_HF_MODEL_OR_LORA_REPO \
-  --base-model Qwen/Qwen2.5-7B-Instruct \
+  --base-model gradients-io-tournaments/swe-base-qwen3-8b-continuous \
   --num-seeds 2 \
   --seed 42
 ```

--- a/tests/validator/tournament/test_continuous_sft_constants.py
+++ b/tests/validator/tournament/test_continuous_sft_constants.py
@@ -30,11 +30,14 @@ class TestFinalRoundComposition:
         expected = sum(t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.values()) + t_cst.FINAL_ROUND_CONTINUOUS_SFT_TASKS
         assert t_cst.FINAL_ROUND_TEXT_TASKS == expected == 5
 
+    def test_boss_round_oversampled_task_count_default_is_disabled(self):
+        assert t_cst.FINAL_ROUND_OVERSAMPLED_TASKS == 0
+
 
 class TestLineages:
-    def test_lineage_is_qwen_with_expected_seed(self):
+    def test_lineage_is_qwen3_14b_with_expected_seed(self):
         # Seed-repo typo would silently train the wrong base every week.
-        assert t_cst.CONTINUOUS_SFT_LINEAGES == {"qwen": "Qwen/Qwen3-8B-Base"}
+        assert t_cst.CONTINUOUS_SFT_LINEAGES == {"qwen3-14b": "Qwen/Qwen3-14B"}
 
     def test_training_hours_fallback_is_four(self):
         # Initial/fallback only — post-prep the throughput pipeline resizes the budget.
@@ -80,7 +83,7 @@ class TestIsContinuousSftTask:
 
 class TestSeedRouting:
     def test_seed_repo_for_ds_pins_the_lineage_seed(self):
-        assert t_cst.continuous_sft_seed_repo_for_ds(t_cst.continuous_sft_ds("qwen", "x")) == "Qwen/Qwen3-8B-Base"
+        assert t_cst.continuous_sft_seed_repo_for_ds(t_cst.continuous_sft_ds("qwen3-14b", "x")) == "Qwen/Qwen3-14B"
 
     def test_seed_repo_none_for_non_continuous_ds(self):
         assert t_cst.continuous_sft_seed_repo_for_ds("tatsu-lab/alpaca") is None

--- a/tests/validator/tournament/test_oversampled_later_models.py
+++ b/tests/validator/tournament/test_oversampled_later_models.py
@@ -1,10 +1,10 @@
-"""Text tournaments oversample the 2026+ model pool into two guaranteed slots.
+"""Text tournaments oversample the 2026+ model pool in configured slots.
 
 Round 1: exactly one task across all groups plays on a model from OVERSAMPLED_LATER_MODELS,
-whatever the group count is. Boss round: the first of the two instruct tasks does.
+whatever the group count is.
 
-Both slots are drawn from a round_id-seeded rng, so a partially created round that gets retried
-resumes onto the same slot and the same model rather than minting a second oversampled task.
+All oversampled picks are round_id-seeded so a partially created round that gets retried
+resumes onto the same slot/model pattern rather than minting extras.
 """
 
 from types import SimpleNamespace
@@ -131,70 +131,26 @@ def _patch_boss_seams(monkeypatch) -> AsyncMock:
     return created
 
 
-async def test_boss_round_gives_exactly_one_task_an_oversampled_model(monkeypatch):
+async def test_boss_round_with_zero_configured_oversampled_tasks_sets_no_override(monkeypatch):
+    monkeypatch.setattr(t_cst, "FINAL_ROUND_OVERSAMPLED_TASKS", 0)
+    created = _patch_boss_seams(monkeypatch)
+
+    await task_creator._create_new_text_boss_round_tasks("tourn", "tourn_round_009", MagicMock())
+
+    assert [c.kwargs.get("model_id_override") for c in created.call_args_list] == [None, None, None, None]
+
+
+async def test_boss_round_with_one_configured_oversampled_task_sets_exactly_one_override(monkeypatch):
+    monkeypatch.setattr(t_cst, "FINAL_ROUND_OVERSAMPLED_TASKS", 1)
     created = _patch_boss_seams(monkeypatch)
 
     await task_creator._create_new_text_boss_round_tasks("tourn", "tourn_round_009", MagicMock())
 
     overrides = [c.kwargs.get("model_id_override") for c in created.call_args_list]
-    assert len(overrides) == sum(t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.values())
     picked = [o for o in overrides if o is not None]
+    assert len(overrides) == sum(t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.values())
     assert len(picked) == 1
     assert picked[0] in POOL_IDS
-
-
-async def test_boss_round_oversampled_slot_is_not_always_instruct(monkeypatch):
-    """The slot is drawn over instruct/dpo/grpo, not pinned to instruct."""
-    seen: set[TaskType] = set()
-    for round_number in range(40):
-        created = _patch_boss_seams(monkeypatch)
-        await task_creator._create_new_text_boss_round_tasks(
-            "tourn", f"tourn_round_{round_number:03d}", MagicMock()
-        )
-        seen.update(
-            call.args[0] for call in created.call_args_list if call.kwargs.get("model_id_override")
-        )
-
-    assert seen == set(t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION)
-
-
-@pytest.mark.parametrize(
-    "existing_model_id, expected_picks",
-    [
-        (next(iter(POOL_IDS)), 0),  # the oversampled task already exists -> don't mint a second
-        ("Qwen/Qwen2.5-7B-Instruct", 1),  # a normal draw exists -> the round still owes one
-    ],
-)
-async def test_boss_round_resume_keeps_exactly_one_oversampled_task(
-    monkeypatch, existing_model_id, expected_picks
-):
-    """A partially created round is completed by looking at what it already plays, not at how many
-    tasks have been created."""
-    existing = [SimpleNamespace(task_id="existing")]
-    monkeypatch.setattr(task_creator, "_get_existing_tasks_by_identifier", AsyncMock(return_value=existing))
-    monkeypatch.setattr(
-        task_creator.task_sql,
-        "get_task",
-        AsyncMock(
-            return_value=SimpleNamespace(
-                task_id="existing", task_type=TaskType.INSTRUCTTEXTTASK, ds="ds", model_id=existing_model_id
-            )
-        ),
-    )
-    monkeypatch.setattr(t_cst, "is_continuous_sft_task", lambda task: False)
-    for name in ("_get_text_models", "_get_instruct_text_datasets", "_get_dpo_datasets"):
-        monkeypatch.setattr(task_creator, name, lambda *a, **k: MagicMock())
-    monkeypatch.setattr(task_creator, "warn_orphaned_continuous_sft_state", AsyncMock())
-    monkeypatch.setattr(task_creator, "_create_continuous_sft_boss_task", AsyncMock(return_value=MagicMock()))
-    created = AsyncMock(side_effect=lambda task_type, *a, **k: SimpleNamespace(task_id="t", task_type=task_type))
-    monkeypatch.setattr(task_creator, "_create_single_new_text_task", created)
-
-    await task_creator._create_new_text_boss_round_tasks("tourn", "tourn_round_009", MagicMock())
-
-    instruct_calls = [c for c in created.call_args_list if c.args[0] == TaskType.INSTRUCTTEXTTASK]
-    assert len(instruct_calls) == 1  # the round had one already
-    picks = [c for c in created.call_args_list if c.kwargs.get("model_id_override") in POOL_IDS]
-    assert len(picks) == expected_picks
 
 
 async def test_draw_deciders_never_get_an_oversampled_model(monkeypatch):

--- a/tests/validator/tournament/test_pre_boss_task.py
+++ b/tests/validator/tournament/test_pre_boss_task.py
@@ -96,7 +96,7 @@ class TestReplacementRouting:
             task_id="orig-task",
             task_type=TaskType.CHATTASK,
             training_start_point=TrainingStartPoint.CONTINUOUS_SFT,
-            ds="continuous-sft:qwen:chunk-00003",
+            ds="continuous-sft:qwen3-14b:chunk-00003",
             status=TaskStatus.PREP_TASK_FAILURE.value,
             model_id="miner-org/carried-winner",
             model_params_count=0,
@@ -112,8 +112,8 @@ class TestReplacementRouting:
         same_type_mock.assert_not_awaited()
         assert new_task_id == "new-task"
         _, lineage, seed_model = recreate_mock.call_args.args
-        assert lineage == "qwen"
-        assert seed_model == t_cst.CONTINUOUS_SFT_LINEAGES["qwen"]
+        assert lineage == "qwen3-14b"
+        assert seed_model == t_cst.CONTINUOUS_SFT_LINEAGES["qwen3-14b"]
 
     async def test_pre_boss_replacement_reforces_the_model(self, monkeypatch):
         original = SimpleNamespace(

--- a/validator/tournament/constants.py
+++ b/validator/tournament/constants.py
@@ -108,7 +108,9 @@ ENV_ENVS_PER_ROUND_MULTIPLIER = 2  # R1=2, R2=4, R3=6 (capped at total available
 ENV_TRAINING_HOURS = 1.5
 ENV_TRAINING_HOURS_SWE_INFINITE = ENV_TRAINING_HOURS + 1.0
 ENV_TRAINING_HOURS_BOSS_ROUND_FROM_SCRATCH = 3.0
-ENV_TARGET_TOURN_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+# Clean copy of the retired qwen (Qwen3-8B-Base) continuous-SFT final winner; base for the
+# guaranteed swe_infinite boss task (TrainingStartPoint.PREVIOUS_WINNER / target-model start).
+ENV_TARGET_TOURN_MODEL = "gradients-io-tournaments/swe-base-qwen3-8b-continuous"
 # If set, forces this game to be the boss (final) round task and excludes it from earlier rounds.
 # Set to None to let any game randomly be the boss round.
 FORCED_BOSS_ENVIRONMENT: EnvironmentName | None = EnvironmentName.SWE_INFINITE
@@ -161,6 +163,9 @@ FINAL_ROUND_TEXT_TASK_DISTRIBUTION: dict[TaskType, int] = {
 }
 
 PROBABILITY_OF_A_BIG_TEXT_MODEL = 0.2
+# Number of boss-round text tasks (from FINAL_ROUND_TEXT_TASK_DISTRIBUTION) to force onto
+# OVERSAMPLED_LATER_MODELS. Set to 0 to disable without removing the wiring.
+FINAL_ROUND_OVERSAMPLED_TASKS = 0
 
 # --- Continuous-SFT boss task ---------------------------------------------------------------
 # Chat-SFT lineages carried across tournaments; each round trains the next stage-1 chunk from the
@@ -171,7 +176,7 @@ PROBABILITY_OF_A_BIG_TEXT_MODEL = 0.2
 # Seeds must be standard architectures: eval and model-prep load miner-controlled repos with
 # trust_remote_code off, so a custom-arch seed would not load.
 CONTINUOUS_SFT_LINEAGES: dict[str, str] = {
-    "qwen": "Qwen/Qwen3-8B-Base",
+    "qwen3-14b": "Qwen/Qwen3-14B",
 }
 FINAL_ROUND_CONTINUOUS_SFT_TASKS = len(CONTINUOUS_SFT_LINEAGES)
 

--- a/validator/tournament/task_creator.py
+++ b/validator/tournament/task_creator.py
@@ -566,19 +566,15 @@ async def _create_group_text_tasks(
     return tasks
 
 
-def _oversampled_boss_task_type(round_id: str) -> TaskType:
-    """Which boss-round task type carries the oversampled model, drawn from a round_id-seeded rng.
-
-    Uniform over the round's task *slots* rather than over types, so with a 2/1/1 instruct/dpo/grpo
-    mix the model lands on an instruct task half the time. Seeded so a resumed round re-picks the
-    same type, and paired with the has-a-pool-task guard so a re-pick cannot add a second one.
-    """
-    slots = [
-        task_type
-        for task_type, count in t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.items()
-        for _ in range(count)
-    ]
-    return random.Random(f"{round_id}:oversampled_type").choice(slots)
+async def _round_oversampled_task_count(round_id: str, config: Config) -> int:
+    """How many tasks in this round already play a model from OVERSAMPLED_LATER_MODELS."""
+    pool_ids = {model.model_id for model in OVERSAMPLED_LATER_MODELS}
+    count = 0
+    for tourn_task in await _get_existing_tasks_by_identifier(round_id, config):
+        task_obj = await task_sql.get_task(tourn_task.task_id, config.psql_db)
+        if task_obj and task_obj.model_id in pool_ids:
+            count += 1
+    return count
 
 
 async def _round_already_has_oversampled_task(round_id: str, config: Config) -> bool:
@@ -588,12 +584,29 @@ async def _round_already_has_oversampled_task(round_id: str, config: Config) -> 
     outside the main creation loop — a draw decider, a replacement for a failed task — cannot hand
     out a second oversampled slot.
     """
-    pool_ids = {model.model_id for model in OVERSAMPLED_LATER_MODELS}
-    for tourn_task in await _get_existing_tasks_by_identifier(round_id, config):
-        task_obj = await task_sql.get_task(tourn_task.task_id, config.psql_db)
-        if task_obj and task_obj.model_id in pool_ids:
-            return True
-    return False
+    return (await _round_oversampled_task_count(round_id, config)) > 0
+
+
+def _oversampled_boss_task_type_counts(
+    round_id: str, pending_slots: list[TaskType], num_oversampled_tasks: int
+) -> dict[TaskType, int]:
+    """Pick up to num_oversampled_tasks pending boss slots and return oversampled counts per type.
+
+    Selection is round_id-seeded so retries are stable for the same pending-slot layout.
+    """
+    if num_oversampled_tasks <= 0 or not pending_slots:
+        return {}
+
+    picks = min(num_oversampled_tasks, len(pending_slots))
+    indices = list(range(len(pending_slots)))
+    random.Random(f"{round_id}:oversampled_slots").shuffle(indices)
+    chosen = indices[:picks]
+
+    per_type: dict[TaskType, int] = {}
+    for index in chosen:
+        task_type = pending_slots[index]
+        per_type[task_type] = per_type.get(task_type, 0) + 1
+    return per_type
 
 
 def _oversampled_model_slot(round_data: GroupRound, tasks_per_group: int) -> int | None:
@@ -826,26 +839,26 @@ async def _create_new_text_boss_round_tasks(tournament_id: str, round_id: str, c
         tasks.append(task_obj)
 
     # Fixed mix: 2 instruct + 1 dpo + 1 grpo (FINAL_ROUND_TEXT_TASK_DISTRIBUTION) + continuous-SFT.
-    # One of those tasks — any type, drawn uniformly over the slots — plays on a 2026+ model from
-    # OVERSAMPLED_LATER_MODELS. The gate is "this round has no pool-model task yet", not a
-    # creation-order index, so a task minted outside this loop (draw decider, replacement) cannot
-    # produce a second one. Continuous-SFT is excluded: its model is the carried lineage winner.
-    oversampled_done = await _round_already_has_oversampled_task(round_id, config)
-    oversampled_type = _oversampled_boss_task_type(round_id)
+    # Continuous-SFT is excluded: its model is the carried lineage winner.
+    pending_slots: list[TaskType] = []
+    for task_type, target_count in t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.items():
+        already = existing_task_type_counts.get(task_type.value, 0)
+        pending_slots.extend([task_type] * max(0, target_count - already))
+
+    existing_oversampled = await _round_oversampled_task_count(round_id, config)
+    oversampled_remaining = max(0, t_cst.FINAL_ROUND_OVERSAMPLED_TASKS - existing_oversampled)
+    oversampled_type_counts = _oversampled_boss_task_type_counts(round_id, pending_slots, oversampled_remaining)
+
     for task_type, target_count in t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.items():
         already = existing_task_type_counts.get(task_type.value, 0)
         for _ in range(target_count - already):
             models = big_models if random.random() < t_cst.PROBABILITY_OF_A_BIG_TEXT_MODEL else standard_models
-            model_id_override = (
-                sample_oversampled_later_model(random.Random(f"{round_id}:oversampled_model"))
-                if task_type == oversampled_type and not oversampled_done
-                else None
-            )
-            if model_id_override:
-                oversampled_done = True
-                logger.info(
-                    f"Boss round {task_type.value} task uses oversampled later model {model_id_override}"
-                )
+            model_id_override = None
+            remaining_for_type = oversampled_type_counts.get(task_type, 0)
+            if remaining_for_type > 0:
+                model_id_override = sample_oversampled_later_model(random.Random(f"{round_id}:oversampled_model"))
+                oversampled_type_counts[task_type] = remaining_for_type - 1
+                logger.info(f"Boss round {task_type.value} task uses oversampled later model {model_id_override}")
             task = await _create_single_new_text_task(
                 task_type,
                 tournament_id,


### PR DESCRIPTION
## Summary
- Rebased continuous text-SFT lineage to a fresh `qwen3-14b` seed (`Qwen/Qwen3-14B`).
- Kept boss-round oversampling logic, but made it configurable and disabled by default (`FINAL_ROUND_OVERSAMPLED_TASKS = 0`).
- Repointed environment SWE target base to the cleaned model repo:
  `gradients-io-tournaments/swe-base-qwen3-8b-continuous`.
- Updated miner docs and tournament tests to match the new lineage and oversampling behavior.

## Why
- Start a fresh continuous chain on a stronger base while retaining the ability to re-enable boss oversampling with a single constant change.
- Use a stable, clearly named SWE target model artifact with explicit lineage provenance.

## Validation
- `python -m ruff check validator/tournament/constants.py`
- `python -m pytest -q -o addopts='' tests/validator/tournament/test_env_tournament_advancement.py`
- Target repo verified contains required files (`config.json`, `model.safetensors`, tokenizer files, `chat_template.jinja`, `README.md`) and tool-calling template signals.