### PR TITLE
Preserve replacement-task invariants across prep-failure reroutes.

### DIFF
--- a/tests/validator/tournament/test_replacement_invariants.py
+++ b/tests/validator/tournament/test_replacement_invariants.py
@@ -1,0 +1,142 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from core.constants.environments import EnvironmentName
+from core.constants.environments import TrainingStartPoint
+from core.models.image_models import ImageModelType
+from core.models.task_models import TaskStatus
+from core.models.task_models import TaskType
+from validator.tasks.models import EnvRawTask
+from validator.tournament import task_creator
+
+
+def _patch_replace_seams(monkeypatch, original_task):
+    monkeypatch.setattr(task_creator.task_sql, "get_task", AsyncMock(return_value=original_task))
+    monkeypatch.setattr(task_creator.task_sql, "get_nodes_assigned_to_task", AsyncMock(return_value=[]))
+    monkeypatch.setattr(task_creator.task_sql, "delete_task", AsyncMock())
+    monkeypatch.setattr(task_creator, "_create_and_register_tournament_task", AsyncMock())
+
+
+async def test_round_one_oversampled_replacement_preserves_model(monkeypatch):
+    original = SimpleNamespace(
+        task_id="orig-task",
+        task_type=TaskType.INSTRUCTTEXTTASK,
+        status=TaskStatus.PREP_TASK_FAILURE.value,
+        model_id=task_creator.OVERSAMPLED_LATER_MODELS[0].model_id,
+        model_params_count=2_000_000_000,
+    )
+    _patch_replace_seams(monkeypatch, original)
+
+    replacement_mock = AsyncMock(return_value=SimpleNamespace(task_id="new-task", task_type=TaskType.INSTRUCTTEXTTASK))
+    monkeypatch.setattr(task_creator, "_create_round_one_group_text_replacement_task", replacement_mock)
+
+    new_task_id = await task_creator.replace_tournament_task(
+        "orig-task", "tourn", "tourn_round_001", "tourn_round_001_group_001", None, MagicMock()
+    )
+
+    assert new_task_id == "new-task"
+    replacement_mock.assert_awaited_once()
+    assert replacement_mock.call_args.kwargs["model_id_override"] == original.model_id
+
+
+async def test_round_one_non_oversampled_replacement_keeps_small_pool(monkeypatch):
+    original = SimpleNamespace(
+        task_id="orig-task",
+        task_type=TaskType.INSTRUCTTEXTTASK,
+        status=TaskStatus.PREP_TASK_FAILURE.value,
+        model_id="Qwen/Qwen2.5-3B",
+        model_params_count=3_000_000_000,
+    )
+    _patch_replace_seams(monkeypatch, original)
+
+    replacement_mock = AsyncMock(return_value=SimpleNamespace(task_id="new-task", task_type=TaskType.INSTRUCTTEXTTASK))
+    monkeypatch.setattr(task_creator, "_create_round_one_group_text_replacement_task", replacement_mock)
+
+    await task_creator.replace_tournament_task(
+        "orig-task", "tourn", "tourn_round_001", "tourn_round_001_group_001", None, MagicMock()
+    )
+
+    replacement_mock.assert_awaited_once()
+    assert replacement_mock.call_args.kwargs["model_id_override"] is None
+
+
+async def test_final_round_oversampled_replacement_passes_override_to_same_type(monkeypatch):
+    original = SimpleNamespace(
+        task_id="orig-task",
+        task_type=TaskType.DPOTASK,
+        status=TaskStatus.PREP_TASK_FAILURE.value,
+        model_id=task_creator.OVERSAMPLED_LATER_MODELS[0].model_id,
+        model_params_count=14_000_000_000,
+    )
+    _patch_replace_seams(monkeypatch, original)
+
+    same_type_mock = AsyncMock(return_value=SimpleNamespace(task_id="new-task", task_type=TaskType.DPOTASK))
+    monkeypatch.setattr(task_creator, "create_new_task_of_same_type", same_type_mock)
+
+    new_task_id = await task_creator.replace_tournament_task(
+        "orig-task", "tourn", "tourn_round_004", None, "tourn_round_004_pair_001", MagicMock(), is_final_round=True
+    )
+
+    assert new_task_id == "new-task"
+    same_type_mock.assert_awaited_once()
+    assert same_type_mock.call_args.kwargs["model_id_override"] == original.model_id
+
+
+async def test_image_replacement_filters_to_original_model_type(monkeypatch):
+    image_task = SimpleNamespace(task_type=TaskType.IMAGETASK, model_type=ImageModelType.Z_IMAGE)
+
+    async def image_pool(_keypair):
+        yield SimpleNamespace(model_id="repo/a", model_type=ImageModelType.KREA2)
+        yield SimpleNamespace(model_id="repo/b", model_type=ImageModelType.Z_IMAGE)
+
+    async def fake_create_synthetic_image_task(_config, models):
+        selected = await anext(models)
+        assert selected.model_type == ImageModelType.Z_IMAGE
+        return SimpleNamespace(task_id="img-task", task_type=TaskType.IMAGETASK)
+
+    monkeypatch.setattr(task_creator, "_get_image_models", image_pool)
+    monkeypatch.setattr(task_creator, "create_synthetic_image_task", fake_create_synthetic_image_task)
+
+    created = await task_creator.create_new_task_of_same_type(image_task, MagicMock())
+    assert created.task_id == "img-task"
+
+
+async def test_environment_replacement_preserves_identity_fields(monkeypatch):
+    original = EnvRawTask(
+        is_organic=False,
+        status=TaskStatus.PREP_TASK_FAILURE.value,
+        model_id="Qwen/Qwen3-8B",
+        ds="env_task_dummy_dataset",
+        account_id=uuid4(),
+        hours_to_complete=3.5,
+        created_at=datetime.utcnow(),
+        termination_at=datetime.utcnow(),
+        model_params_count=8_000_000_000,
+        training_start_point=TrainingStartPoint.PREVIOUS_WINNER,
+        environment_names=[EnvironmentName.SWE_INFINITE],
+        environment_weights=[],
+        eval_seed=123456,
+    )
+    _patch_replace_seams(monkeypatch, original)
+
+    env_create_mock = AsyncMock(return_value=SimpleNamespace(task_id="env-new", task_type=TaskType.ENVIRONMENTTASK))
+    monkeypatch.setattr(task_creator, "create_synthetic_env_task", env_create_mock)
+    monkeypatch.setattr(task_creator, "_get_text_models", lambda *_args, **_kwargs: MagicMock())
+    monkeypatch.setattr(task_creator, "_get_instruct_text_datasets", lambda *_args, **_kwargs: MagicMock())
+
+    new_task_id = await task_creator.replace_tournament_task(
+        "orig-task", "tourn", "tourn_round_004", None, "tourn_round_004_pair_001", MagicMock(), is_final_round=True
+    )
+
+    assert new_task_id == "env-new"
+    env_create_mock.assert_awaited_once()
+    kwargs = env_create_mock.call_args.kwargs
+    assert kwargs["model_id_override"] == original.model_id
+    assert kwargs["training_start_point"] == original.training_start_point
+    assert kwargs["environment_names_override"] == original.environment_names
+    assert kwargs["eval_seed_override"] == original.eval_seed
+    assert kwargs["hours_override"] == original.hours_to_complete
+    assert kwargs["num_environments"] == len(original.environment_names)

--- a/validator/tournament/task_creator.py
+++ b/validator/tournament/task_creator.py
@@ -41,6 +41,12 @@ from validator.tournament.models import TournamentType
 logger = get_logger(__name__)
 
 
+def _is_oversampled_later_model_task(task) -> bool:
+    """Whether this task is pinned to one of the enforced oversampled later models."""
+    pool_ids = {model.model_id for model in OVERSAMPLED_LATER_MODELS}
+    return getattr(task, "model_id", None) in pool_ids
+
+
 def _env_names_excluding_forced_boss() -> list[EnvironmentName]:
     forced = t_cst.FORCED_BOSS_ENVIRONMENT
     return [env for env in EnvironmentName if env != forced]
@@ -432,6 +438,13 @@ async def _create_single_image_task_with_retry(
     return task
 
 
+async def _image_models_of_type(config: Config, model_type: ImageModelType):
+    """Yield only models matching model_type from the image pool."""
+    async for model in _get_image_models(config.keypair):
+        if model.model_type == model_type:
+            yield model
+
+
 async def _create_task_by_type(
     task_type: TaskType,
     config: Config,
@@ -754,15 +767,38 @@ async def _create_single_probability_task(
         return await create_synthetic_grpo_task(config, models, instruct_datasets)
 
 
-async def create_new_task_of_same_type(task: RawTask, config: Config) -> RawTask:
+async def _create_environment_replacement_task(task: EnvRawTask, config: Config) -> RawTask:
+    """Recreate an environment task preserving all enforced identity fields."""
+    models = _get_text_models(config.keypair)
+    instruct_datasets = _get_instruct_text_datasets(config.keypair)
+    return await create_synthetic_env_task(
+        config,
+        models,
+        instruct_datasets,
+        num_environments=len(task.environment_names),
+        model_id_override=task.model_id,
+        training_start_point=task.training_start_point,
+        environment_names_override=task.environment_names,
+        eval_seed_override=task.eval_seed,
+        hours_override=task.hours_to_complete,
+    )
+
+
+async def create_new_task_of_same_type(task: RawTask, config: Config, model_id_override: str | None = None) -> RawTask:
     if task.task_type == TaskType.IMAGETASK:
-        models = _get_image_models(config.keypair)
+        model_type = getattr(task, "model_type", None)
+        models = _image_models_of_type(config, model_type) if model_type is not None else _get_image_models(config.keypair)
         return await _create_task_by_type(task.task_type, config, models, [], [])
+
+    if task.task_type == TaskType.ENVIRONMENTTASK and isinstance(task, EnvRawTask):
+        return await _create_environment_replacement_task(task, config)
 
     model_params_b = int(task.model_params_count / t_cst.MODEL_PARAMS_TO_BILLIONS)
 
     # Handle case where model params is 0 or very small
-    if model_params_b < t_cst.DEFAULT_MODEL_MIN_SIZE_B:
+    if model_id_override:
+        models = None
+    elif model_params_b < t_cst.DEFAULT_MODEL_MIN_SIZE_B:
         logger.warning(
             f"Original task has very small model params ({task.model_params_count}), "
             f"using default range {t_cst.DEFAULT_MODEL_MIN_SIZE_B}-"
@@ -780,7 +816,14 @@ async def create_new_task_of_same_type(task: RawTask, config: Config) -> RawTask
     instruct_datasets = _get_instruct_text_datasets(config.keypair)
     dpo_datasets = _get_dpo_datasets(config.keypair)
 
-    return await _create_task_by_type(task.task_type, config, models, instruct_datasets, dpo_datasets)
+    return await _create_task_by_type(
+        task.task_type,
+        config,
+        models,
+        instruct_datasets,
+        dpo_datasets,
+        model_id_override=model_id_override,
+    )
 
 
 def _is_round_one_group_text_task(task: RawTask, round_id: str, group_id: str | None, pair_id: str | None) -> bool:
@@ -793,14 +836,20 @@ def _is_round_one_group_text_task(task: RawTask, round_id: str, group_id: str | 
     )
 
 
-async def _create_round_one_group_text_replacement_task(config: Config) -> RawTask:
+async def _create_round_one_group_text_replacement_task(config: Config, model_id_override: str | None = None) -> RawTask:
     """
     Create a replacement task that matches round-1 group text constraints:
     - small text model pool (0.1B-4.0B)
     """
-    models = _get_text_models(config.keypair, smallest_size_b=0.1, largest_size_b=4.0)
+    models = None if model_id_override else _get_text_models(config.keypair, smallest_size_b=0.1, largest_size_b=4.0)
     instruct_datasets = _get_instruct_text_datasets(config.keypair, small_only=True)
-    return await create_synthetic_instruct_text_task(config, models, instruct_datasets, enable_kl=False)
+    return await create_synthetic_instruct_text_task(
+        config,
+        models,
+        instruct_datasets,
+        enable_kl=False,
+        model_id_override=model_id_override,
+    )
 
 
 async def _create_new_text_boss_round_tasks(tournament_id: str, round_id: str, config: Config) -> list[RawTask]:
@@ -1024,18 +1073,13 @@ async def _create_new_image_boss_round_tasks(tournament_id: str, round_id: str, 
         for model_type in t_cst.FINAL_ROUND_IMAGE_TASK_DISTRIBUTION
     }
 
-    async def filtered_models(model_type: ImageModelType):
-        async for model in _get_image_models(config.keypair):
-            if model.model_type == model_type:
-                yield model
-
     for model_type, target_count in t_cst.FINAL_ROUND_IMAGE_TASK_DISTRIBUTION.items():
         remaining_slots = t_cst.FINAL_ROUND_IMAGE_TASKS - len(tasks)
         if remaining_slots <= 0:
             break
         already_created = existing_counts_by_model_type.get(model_type, 0)
         num_to_create = min(max(target_count - already_created, 0), remaining_slots)
-        model_gen = filtered_models(model_type)
+        model_gen = _image_models_of_type(config, model_type)
         for i in range(num_to_create):
             try:
                 task = await _create_single_image_task_with_retry(config, model_gen, i, is_final=True)
@@ -1073,7 +1117,12 @@ async def replace_tournament_task(
     try:
         if _is_round_one_group_text_task(original_task_obj, round_id, group_id, pair_id):
             logger.info("Detected round-1 group text task replacement; enforcing small-model and 2h constraints")
-            new_task = await _create_round_one_group_text_replacement_task(config)
+            replacement_model_override = (
+                original_task_obj.model_id if _is_oversampled_later_model_task(original_task_obj) else None
+            )
+            new_task = await _create_round_one_group_text_replacement_task(
+                config, model_id_override=replacement_model_override
+            )
         elif t_cst.is_continuous_sft_task(original_task_obj):
             # Same lineage, same carried base model; the content service re-materializes the chunk
             # at fresh S3 URLs. Without this branch, create_new_task_of_same_type has no CHATTASK
@@ -1095,8 +1144,18 @@ async def replace_tournament_task(
             # and silently stripped of augmentation/KL/YaRN on the round that decides the title.
             logger.info("Detected pre-boss task replacement; re-forcing the pre-boss model")
             new_task = await _create_pre_boss_task(config, _get_instruct_text_datasets(config.keypair))
+        elif isinstance(original_task_obj, EnvRawTask):
+            logger.info("Detected environment task replacement; preserving start point/model/envs/seed/hours")
+            new_task = await _create_environment_replacement_task(original_task_obj, config)
         else:
-            new_task = await create_new_task_of_same_type(original_task_obj, config)
+            replacement_model_override = (
+                original_task_obj.model_id if _is_oversampled_later_model_task(original_task_obj) else None
+            )
+            new_task = await create_new_task_of_same_type(
+                original_task_obj,
+                config,
+                model_id_override=replacement_model_override,
+            )
         logger.info(f"Successfully created new task {new_task.task_id} of type {new_task.task_type}")
     except Exception as e:
         logger.error(f"Failed to create new task of type {original_task_obj.task_type}: {str(e)}", exc_info=True)


### PR DESCRIPTION
## Summary

This PR fixes prep-failure replacement routing so replacement tasks preserve tournament invariants instead of silently redrawing incompatible task identities.

- Preserve newer-model text enforcement:
  - Round-1 group text replacements now keep the oversampled model when the failed task used one.
  - Generic replacement routing now forwards `model_id_override` for oversampled tasks, including final-round text paths.
- Preserve image invariants:
  - Replacement image tasks now stay on the original task’s `model_type`.
  - Added/reused typed image-model filtering helper so both replacement and final-round image creation follow model-type constraints.
- Preserve environment invariants:
  - Added dedicated environment replacement creation that keeps model, training start point, environment set, eval seed, and training hours.
  - Added explicit env branch in `replace_tournament_task` to avoid default-randomized env recreation.
- Keep existing special-case behavior intact:
  - Continuous-SFT and pre-boss replacement branches remain unchanged, and still take precedence where intended.

## Testing

- Added focused regression tests in `tests/validator/tournament/test_replacement_invariants.py` for:
  - round-1 oversampled text replacement model preservation
  - round-1 non-oversampled text replacement behavior
  - final-round oversampled override propagation through same-type replacement
  - image replacement model-type preservation
  - environment replacement identity-field preservation
- Local lint:
  - `python3 -m ruff check validator/tournament/task_creator.py tests/validator/tournament/test_replacement_invariants.py` ✅
- Local tests:
  - `python3 -m pytest -q -o addopts='' tests/validator/tournament/test_replacement_invariants.py tests/validator/tournament/test_pre_boss_task.py` was blocked in this environment by missing dependency `scalecodec` during collection.
  - `uv` is also unavailable in this environment (`uv: command not found`).