### PR TITLE
one entry per coldkey

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -35,6 +35,7 @@ Before a tournament starts, make sure:
 - Your submitted commit contains the required Dockerfiles, exact LICENSE/NOTICE files, readable source code, and no hidden datasets or pretrained models.
 - Your training script writes the final model to `/app/checkpoints/{task_id}/{expected_repo_name}`.
 - Your coldkey has enough tournament balance for the tournament type.
+- Only one hotkey per coldkey will be enrolled in a given tournament.
 - You have tested the exact Dockerfile and entrypoint locally with the example scripts.
 
 ## What Miners Do
@@ -99,7 +100,7 @@ Tournament fees are deducted from your coldkey balance after your repository pas
 | Image | 0.20 TAO |
 | Environment | 0.30 TAO |
 
-Balances are tracked per coldkey, so hotkeys under the same coldkey share the same tournament balance. Transfer TAO from your coldkey to the collection address:
+Balances are tracked per coldkey, so hotkeys under the same coldkey share the same tournament balance. Only **one tournament entry is allowed per coldkey**: if multiple hotkeys under the same coldkey respond during registration, one is kept and the rest are rejected (no second fee is charged). Transfer TAO from your coldkey to the collection address:
 
 ```text
 5Ef5JgNv14LY4UEQFHbRQkf8TnegDV3AfAbcsJe5T2w6VQdo
@@ -187,7 +188,7 @@ Important details:
 - Use `git rev-parse HEAD` to get the commit you want validators to run.
 - The repository and commit must remain accessible until the tournament completes.
 - You may return different repositories or commits for `text`, `image`, and `environment`.
-- One miner is kept per duplicate IP address and one miner is kept per duplicate GitHub account. If duplicates exist, entries with a valid token are preferred.
+- One miner is kept per coldkey, per IP address, and per GitHub account. Multiple hotkeys under the same coldkey cannot all enter the same tournament: only one entry is kept, and the others are rejected. If duplicates exist, entries with a valid GitHub token are preferred; otherwise the first kept candidate in the registration pass wins.
 
 ### Private Repositories
 

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -216,10 +216,58 @@ async def enroll_tournament_participant_with_fee(
 
     The participant primary key is the idempotency guard. If a restart retries
     the same tournament/hotkey, the existing row prevents another deduction.
+
+    Only one entry is allowed per coldkey: if this coldkey already paid a
+    participation fee for the tournament (via another hotkey), enrollment is refused.
     """
     try:
         async with await psql_db.connection() as connection:
             async with connection.transaction():
+                # Serialize enrollments for this coldkey so two hotkeys cannot race in.
+                await connection.fetchrow(
+                    """
+                    SELECT coldkey
+                    FROM coldkey_balances
+                    WHERE coldkey = $1
+                    FOR UPDATE
+                    """,
+                    coldkey,
+                )
+
+                existing_fee = await connection.fetchval(
+                    """
+                    SELECT 1
+                    FROM balance_events
+                    WHERE tournament_id = $1
+                      AND coldkey = $2
+                      AND event_type = 'participation_fee'
+                    LIMIT 1
+                    """,
+                    participant.tournament_id,
+                    coldkey,
+                )
+                if existing_fee is not None:
+                    already_enrolled = await connection.fetchval(
+                        f"""
+                        SELECT 1
+                        FROM {cst.TOURNAMENT_PARTICIPANTS_TABLE}
+                        WHERE {cst.TOURNAMENT_ID} = $1 AND {cst.HOTKEY} = $2
+                        """,
+                        participant.tournament_id,
+                        participant.hotkey,
+                    )
+                    if already_enrolled is not None:
+                        logger.info(
+                            f"Participant {participant.hotkey} is already enrolled in "
+                            f"tournament {participant.tournament_id}; skipping fee"
+                        )
+                        return True
+                    logger.warning(
+                        f"Rejecting {participant.hotkey}: coldkey {coldkey[:12]}… already "
+                        f"has a tournament entry in {participant.tournament_id}"
+                    )
+                    return False
+
                 inserted = await connection.fetchrow(
                     f"""
                     INSERT INTO {cst.TOURNAMENT_PARTICIPANTS_TABLE}

--- a/validator/tournament/github_validation.py
+++ b/validator/tournament/github_validation.py
@@ -271,3 +271,36 @@ def deduplicate_by_ip_address(nodes: list[RespondingNode]) -> list[RespondingNod
             )
 
     return kept
+
+
+def deduplicate_by_coldkey(nodes: list[RespondingNode]) -> list[RespondingNode]:
+    """Keep a single tournament entry per coldkey (no multi-hotkey farming)."""
+    by_coldkey: defaultdict[str, list[RespondingNode]] = defaultdict(list)
+
+    for node in nodes:
+        by_coldkey[node.node.coldkey].append(node)
+
+    kept: list[RespondingNode] = []
+    for coldkey, group in by_coldkey.items():
+        if len(group) == 1:
+            kept.append(group[0])
+            continue
+
+        with_token = [n for n in group if n.training_repo_response.github_token]
+        without_token = [n for n in group if not n.training_repo_response.github_token]
+
+        if with_token:
+            winner = with_token[0]
+            rejected = with_token[1:] + without_token
+        else:
+            winner = without_token[0]
+            rejected = without_token[1:]
+
+        kept.append(winner)
+        for r in rejected:
+            logger.warning(
+                f"Rejecting {r.node.hotkey} — duplicate coldkey '{coldkey[:12]}…' "
+                f"(kept {winner.node.hotkey})"
+            )
+
+    return kept

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -62,6 +62,7 @@ from validator.tournament.challenger_code_review import evaluate_challenger_code
 from validator.tournament.dedup_gate import apply_r1_eliminations
 from validator.tournament.dedup_gate import detect_r1_hash_duplicates
 from validator.tournament.dedup_gate import evaluate_r2_dedup_gate
+from validator.tournament.github_validation import deduplicate_by_coldkey
 from validator.tournament.github_validation import deduplicate_by_github_account
 from validator.tournament.github_validation import deduplicate_by_ip_address
 from validator.tournament.github_validation import validate_github_tokens
@@ -917,12 +918,26 @@ async def populate_tournament_participants(tournament_id: str, config: Config, p
 
         all_nodes = await get_all_nodes(psql_db)
 
+        persisted_coldkeys: set[str] = set()
+        for participant in persisted_participants:
+            if participant.hotkey == EMISSION_BURN_HOTKEY:
+                continue
+            enrolled_node = await get_node_by_hotkey(participant.hotkey, psql_db)
+            if enrolled_node and enrolled_node.coldkey:
+                persisted_coldkeys.add(enrolled_node.coldkey)
+
         # Existing participant rows are durable proof that their fee was already charged.
-        eligible_nodes = [
-            node
-            for node in all_nodes
-            if node.hotkey != EMISSION_BURN_HOTKEY and node.hotkey not in persisted_hotkeys
-        ]
+        eligible_nodes = []
+        for node in all_nodes:
+            if node.hotkey == EMISSION_BURN_HOTKEY or node.hotkey in persisted_hotkeys:
+                continue
+            if node.coldkey in persisted_coldkeys:
+                logger.warning(
+                    f"Rejecting {node.hotkey} — duplicate coldkey '{node.coldkey[:12]}…' "
+                    f"(coldkey already enrolled in tournament {tournament_id})"
+                )
+                continue
+            eligible_nodes.append(node)
 
         if not eligible_nodes:
             logger.warning("No eligible nodes found for tournament")
@@ -970,6 +985,13 @@ async def populate_tournament_participants(tournament_id: str, config: Config, p
         if len(responding_nodes) < pre_dedup:
             logger.info(
                 f"Deduplicated GitHub accounts: {pre_dedup} -> {len(responding_nodes)} nodes"
+            )
+
+        pre_dedup_coldkey = len(responding_nodes)
+        responding_nodes = deduplicate_by_coldkey(responding_nodes)
+        if len(responding_nodes) < pre_dedup_coldkey:
+            logger.info(
+                f"Deduplicated coldkeys: {pre_dedup_coldkey} -> {len(responding_nodes)} nodes"
             )
 
         logger.info(f"Processing {len(responding_nodes)} responding nodes")

--- a/validator/tournament/utils.py
+++ b/validator/tournament/utils.py
@@ -1,5 +1,6 @@
 from validator.tournament.brackets import draw_group_stage_table
 from validator.tournament.brackets import draw_knockout_bracket
+from validator.tournament.github_validation import deduplicate_by_coldkey
 from validator.tournament.github_validation import deduplicate_by_github_account
 from validator.tournament.github_validation import deduplicate_by_ip_address
 from validator.tournament.github_validation import parse_github_owner_repo
@@ -40,6 +41,7 @@ __all__ = [
     "_get_final_round_participants",
     "_get_scores_for_task",
     "_resolve_boss_round_draws",
+    "deduplicate_by_coldkey",
     "deduplicate_by_github_account",
     "deduplicate_by_ip_address",
     "determine_boss_round_winner",


### PR DESCRIPTION
Only allow a single tournament entry per coldkey so miners cannot enter with multiple hotkeys. Deduplicate responding nodes by coldkey, skip already-enrolled coldkeys on populate retries, and reject a second enrollment when that coldkey already paid the participation fee.