### PR TITLE
Fix pre-boss knockout 3rd place: resolve winner from tasks, not dead pair column

### DIFF
--- a/tests/validator/tournament/test_pre_boss_third_place.py
+++ b/tests/validator/tournament/test_pre_boss_third_place.py
@@ -75,6 +75,10 @@ def _pre_boss_task(model_id: str = PRE_BOSS_MODEL, task_type: TaskType = TaskTyp
     return task
 
 
+def _pair_task(task_id: str = "task-1", pair_id: str = "p1") -> TournamentTask:
+    return TournamentTask(tournament_id="tourn_test", round_id="round_2", task_id=task_id, pair_id=pair_id)
+
+
 @pytest.fixture
 def knockout_loser_mocks():
     with (
@@ -82,47 +86,67 @@ def knockout_loser_mocks():
         patch(f"{PARTICIPANTS_MODULE}.get_tournament_pairs", new_callable=AsyncMock) as pairs,
         patch(f"{PARTICIPANTS_MODULE}.get_tournament_tasks", new_callable=AsyncMock) as tasks,
         patch(f"{PARTICIPANTS_MODULE}.get_task", new_callable=AsyncMock) as task,
+        patch(f"{PARTICIPANTS_MODULE}._resolve_knockout_task_winner", new_callable=AsyncMock) as task_winner,
     ):
-        yield rounds, pairs, tasks, task
+        tasks.return_value = [_pair_task()]
+        yield rounds, pairs, tasks, task, task_winner
 
 
 class TestGetPreBossKnockoutLoser:
     async def test_image_clean_single_pair_returns_loser(self, knockout_loser_mocks):
-        """IMAGE has no PRE_BOSS_MODEL signal - structural check alone is enough."""
-        rounds, pairs, _tasks, _task = knockout_loser_mocks
+        """IMAGE has no PRE_BOSS_MODEL signal - structural check alone is enough.
+
+        The pair's winner is resolved from its task (via ``_resolve_knockout_task_winner``),
+        not read off ``tournament_pairs.winner_hotkey`` - nothing ever writes that column.
+        """
+        rounds, pairs, _tasks, _task, task_winner = knockout_loser_mocks
         rounds.return_value = [_round(2, RoundType.KNOCKOUT)]
         pairs.return_value = [_pair(CHALLENGER, LOSER)]
+        task_winner.return_value = CHALLENGER
 
         result = await get_pre_boss_knockout_loser(_tournament(TournamentType.IMAGE), _final_round(), CHALLENGER, AsyncMock())
 
         assert result == LOSER
 
     async def test_text_requires_pre_boss_model_pin(self, knockout_loser_mocks):
-        rounds, pairs, tasks, task = knockout_loser_mocks
+        rounds, pairs, tasks, task, task_winner = knockout_loser_mocks
         rounds.return_value = [_round(2, RoundType.KNOCKOUT)]
         pairs.return_value = [_pair(CHALLENGER, LOSER)]
-        tasks.return_value = [TournamentTask(tournament_id="tourn_test", round_id="round_2", task_id="task-1")]
+        tasks.return_value = [_pair_task()]
         task.return_value = _pre_boss_task()
+        task_winner.return_value = CHALLENGER
 
         result = await get_pre_boss_knockout_loser(_tournament(TournamentType.TEXT), _final_round(), CHALLENGER, AsyncMock())
 
         assert result == LOSER
 
     async def test_text_without_pre_boss_model_returns_none(self, knockout_loser_mocks):
-        rounds, pairs, tasks, task = knockout_loser_mocks
+        rounds, pairs, tasks, task, task_winner = knockout_loser_mocks
         rounds.return_value = [_round(2, RoundType.KNOCKOUT)]
         pairs.return_value = [_pair(CHALLENGER, LOSER)]
-        tasks.return_value = [TournamentTask(tournament_id="tourn_test", round_id="round_2", task_id="task-1")]
+        tasks.return_value = [_pair_task()]
         task.return_value = _pre_boss_task(model_id="Qwen/SomeOtherModel")
+        task_winner.return_value = CHALLENGER
 
         result = await get_pre_boss_knockout_loser(_tournament(TournamentType.TEXT), _final_round(), CHALLENGER, AsyncMock())
+
+        assert result is None
+
+    async def test_no_decided_task_winner_returns_none(self, knockout_loser_mocks):
+        """Neither side had a resolvable task winner (e.g. both evaluations failed)."""
+        rounds, pairs, _tasks, _task, task_winner = knockout_loser_mocks
+        rounds.return_value = [_round(2, RoundType.KNOCKOUT)]
+        pairs.return_value = [_pair(CHALLENGER, LOSER)]
+        task_winner.return_value = None
+
+        result = await get_pre_boss_knockout_loser(_tournament(TournamentType.IMAGE), _final_round(), CHALLENGER, AsyncMock())
 
         assert result is None
 
     async def test_multi_pair_pre_boss_round_returns_none(self, knockout_loser_mocks):
         """GROUP-shaped small-tournament pre-boss variant (or any multi-pair round) is not
         the clean single head-to-head the payout rule requires."""
-        rounds, pairs, _tasks, _task = knockout_loser_mocks
+        rounds, pairs, _tasks, _task, _task_winner = knockout_loser_mocks
         rounds.return_value = [_round(2, RoundType.KNOCKOUT)]
         pairs.return_value = [_pair(CHALLENGER, LOSER), _pair(OTHER, "5GAnother")]
 
@@ -131,7 +155,7 @@ class TestGetPreBossKnockoutLoser:
         assert result is None
 
     async def test_missing_pre_boss_round_returns_none(self, knockout_loser_mocks):
-        rounds, _pairs, _tasks, _task = knockout_loser_mocks
+        rounds, _pairs, _tasks, _task, _task_winner = knockout_loser_mocks
         rounds.return_value = [_round(1, RoundType.KNOCKOUT)]
 
         result = await get_pre_boss_knockout_loser(_tournament(TournamentType.IMAGE), _final_round(), CHALLENGER, AsyncMock())
@@ -139,7 +163,7 @@ class TestGetPreBossKnockoutLoser:
         assert result is None
 
     async def test_pre_boss_round_wrong_type_returns_none(self, knockout_loser_mocks):
-        rounds, _pairs, _tasks, _task = knockout_loser_mocks
+        rounds, _pairs, _tasks, _task, _task_winner = knockout_loser_mocks
         rounds.return_value = [_round(2, RoundType.GROUP)]
 
         result = await get_pre_boss_knockout_loser(_tournament(TournamentType.IMAGE), _final_round(), CHALLENGER, AsyncMock())
@@ -148,9 +172,10 @@ class TestGetPreBossKnockoutLoser:
 
     async def test_loser_colliding_with_challenger_returns_none(self, knockout_loser_mocks):
         """Data inconsistency: the pair's non-winner is somehow the resolved challenger."""
-        rounds, pairs, _tasks, _task = knockout_loser_mocks
+        rounds, pairs, _tasks, _task, task_winner = knockout_loser_mocks
         rounds.return_value = [_round(2, RoundType.KNOCKOUT)]
         pairs.return_value = [_pair(LOSER, CHALLENGER)]  # winner=LOSER, other side=CHALLENGER
+        task_winner.return_value = LOSER
 
         result = await get_pre_boss_knockout_loser(_tournament(TournamentType.IMAGE), _final_round(), CHALLENGER, AsyncMock())
 

--- a/validator/tournament/participants.py
+++ b/validator/tournament/participants.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import aiohttp
 
 from core.datasets.whitelist import validate_requested_datasets
@@ -19,6 +21,7 @@ from validator.tournament.models import TournamentData
 from validator.tournament.models import TournamentParticipant
 from validator.tournament.models import TournamentRoundData
 from validator.tournament.models import TournamentType
+from validator.tournament.round_results import _resolve_knockout_task_winner
 
 
 logger = get_logger(__name__)
@@ -46,9 +49,14 @@ async def get_pre_boss_knockout_loser(
 
     Only returns a hotkey when the pre-boss round is unambiguous: exactly one
     KNOCKOUT round immediately preceding the final round, with exactly one pair
-    and a decided winner_hotkey, and - for TEXT tournaments - every task in that
-    round pinned to PRE_BOSS_MODEL. Anything less structurally clean returns None
-    so the caller falls back to top-2-only payout.
+    and a decided winner, and - for TEXT tournaments - every task in that round
+    pinned to PRE_BOSS_MODEL. Anything less structurally clean returns None so
+    the caller falls back to top-2-only payout.
+
+    The pair's winner is resolved from its tasks via ``_resolve_knockout_task_winner``
+    (majority across tasks if there's more than one) rather than read off
+    ``tournament_pairs.winner_hotkey`` - nothing in the tournament pipeline ever
+    writes that column, so it is always NULL.
     """
     rounds = await get_tournament_rounds(tournament.tournament_id, psql_db)
     pre_boss = next((r for r in rounds if r.round_number == final_round.round_number - 1), None)
@@ -58,20 +66,26 @@ async def get_pre_boss_knockout_loser(
     pairs = await get_tournament_pairs(pre_boss.round_id, psql_db)
     if len(pairs) != 1:
         return None
-
     pair = pairs[0]
-    if not pair.winner_hotkey or pair.winner_hotkey not in (pair.hotkey1, pair.hotkey2):
+
+    round_tasks = await get_tournament_tasks(pre_boss.round_id, psql_db)
+    pair_tasks = [task for task in round_tasks if task.pair_id == pair.pair_id]
+    if not pair_tasks:
         return None
 
-    loser = pair.hotkey2 if pair.winner_hotkey == pair.hotkey1 else pair.hotkey1
-    if loser in (EMISSION_BURN_HOTKEY, challenger_hotkey, pair.winner_hotkey):
+    task_winners = [w for w in [await _resolve_knockout_task_winner(task, psql_db) for task in pair_tasks] if w]
+    if not task_winners:
+        return None
+    winner_hotkey = Counter(task_winners).most_common(1)[0][0]
+    if winner_hotkey not in (pair.hotkey1, pair.hotkey2):
+        return None
+
+    loser = pair.hotkey2 if winner_hotkey == pair.hotkey1 else pair.hotkey1
+    if loser in (EMISSION_BURN_HOTKEY, challenger_hotkey, winner_hotkey):
         return None
 
     if tournament.tournament_type == TournamentType.TEXT:
-        round_tasks = await get_tournament_tasks(pre_boss.round_id, psql_db)
-        if not round_tasks:
-            return None
-        tasks_full = [await get_task(task.task_id, psql_db) for task in round_tasks]
+        tasks_full = [await get_task(task.task_id, psql_db) for task in pair_tasks]
         if not all(task and is_pre_boss_task(task) for task in tasks_full):
             return None
 


### PR DESCRIPTION
## Summary

`get_pre_boss_knockout_loser` (merged in #1362) determined the pre-boss knockout pair's winner by reading `tournament_pairs.winner_hotkey`. That column is never populated anywhere in the codebase: `insert_tournament_pairs` only writes `pair_id, round_id, hotkey1, hotkey2` and nothing updates it afterward, so it's always `NULL` for every pair, in every tournament, past and future.

As a result, the function's first guard (`if not pair.winner_hotkey: return None`) tripped every time, and text/image tournaments silently fell back to top-2-only payout instead of paying a 3rd place — confirmed against today's live production audit snapshot, where both the Aug-31 text and image tournaments have a clean, decided single-pair pre-boss knockout round that should have produced a 3rd place but didn't.

## Fix

Resolve the pair's winner from its own task(s) instead, using the same `_resolve_knockout_task_winner` helper `get_knockout_winners` already relies on for normal round advancement (majority vote across tasks if a pair spans more than one). `tournament_pairs.winner_hotkey` is no longer read.

`get_pre_boss_group_runner_up` (the ENVIRONMENT counterpart) was unaffected — it already derives everything from task results directly.

## Test plan

- [x] `tests/validator/tournament` + `tests/validator/scoring`: 333 passed, 1 pre-existing unrelated failure (`test_continuous_sft_gpu_hours.py`, present on `main` before this change too).
- [x] Updated `test_pre_boss_third_place.py`'s knockout-loser tests to mock the new task-based winner resolution instead of the dead `winner_hotkey` field; added a case for "no decided task winner".
- [x] Verified end-to-end against today's live production audit snapshot (`GET /auditing/scores-url`): ran the real `get_pre_boss_knockout_loser` and `get_pre_boss_group_runner_up` with only their DB calls stubbed (using data straight from that snapshot) — text and image now correctly resolve their actual pre-boss loser as 3rd place, matching what the environment tournament already did correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)