### PR TITLE
Auditor: loop continuously to match validator weight-set frequency

### DIFF
--- a/ops/auditing/audit.py
+++ b/ops/auditing/audit.py
@@ -136,6 +136,7 @@ async def main():
     if uid is None:
         raise ValueError(f"Can't find hotkey {config.keypair.ss58_address} for our keypair on netuid: {config.netuid}.")
 
+    consecutive_failures = 0
     while True:
         substrate, current_block = query_substrate(substrate, "System", "Number", [], return_value=True)
         substrate, last_updated_value = query_substrate(
@@ -155,9 +156,21 @@ async def main():
             await asyncio.sleep(sleep_duration)
             continue
 
-        success = await audit_weights(config)
+        try:
+            success = await audit_weights(config)
+        except Exception as e:
+            logger.error(f"Failed to audit and set weights: {e}")
+            logger.exception(e)
+            success = False
+
         if success:
-            break
+            consecutive_failures = 0
+            logger.info("Successfully audited and set weights! Sleeping for 25 blocks before next check...")
+            await asyncio.sleep(12 * 25)
+        else:
+            consecutive_failures += 1
+            logger.info(f"Failed to audit and set weights {consecutive_failures} times in a row - sleeping for a bit...")
+            await asyncio.sleep(12 * 25)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- The auditor's `main()` loop (`ops/auditing/audit.py`) previously `break`d and returned after a single successful `audit_weights` call, relying on the process exiting cleanly and pm2 (or the commit-driven `run_auditor_autoupdate.py`) restarting it before it would set weights again in practice. In practice the process doesn't exit cleanly (no substrate/thread cleanup), so pm2's autorestart never fires and the auditor only re-runs when a new commit lands on `origin/main` — far less often than the validator sets weights.
- This mirrors `set_weights_periodically`'s cadence from `validator/scoring/weights.py`: after checking the on-chain `WeightsSetRateLimit`, the auditor now keeps looping in-process, sleeping ~25 blocks after both success and failure before re-checking, instead of exiting. This gives it the same weight-setting rhythm as the main validator without depending on process restarts.

## Test plan
- [x] `python -m py_compile ops/auditing/audit.py`
- [ ] Deploy to a validator/auditor box and confirm it sets weights repeatedly (~every rate-limit window) without needing an external restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)