### PR TITLE
Document and alert on the weekly tournament completion deadline

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -60,6 +60,12 @@ The scheduler only starts a new tournament when there is no active or pending to
 
 The first tournament of a type can be created immediately when no previous tournament exists. After that, the previous tournament must be completed and the next scheduled window must arrive.
 
+### Weekly Completion Deadline
+
+Every tournament, regardless of type, is expected to be completed by **Friday at 14:00 UTC** of the week it started. This deadline is independent of training time and GPU availability during the week, and a round being reverted does not push the deadline out — it only shrinks the time left to finish, as long as the tournament still fits before Friday.
+
+Completion itself is a manual step: once a winner is decided, the team reviews the winning submission's code to check for exploits and confirm it reflects a genuine training improvement before marking the tournament completed. To make sure that review doesn't slip past the deadline, the validator posts a Discord reminder 30 minutes before the Friday 14:00 UTC cutoff for any tournament that is still active at that point.
+
 ## Registration Requirements
 
 ### Subnet Registration

--- a/validator/tournament/constants.py
+++ b/validator/tournament/constants.py
@@ -21,6 +21,14 @@ TOURNAMENT_SCHEDULE_TEXT_HOUR = 11
 TOURNAMENT_SCHEDULE_IMAGE_DAY_OF_WEEK = 0
 TOURNAMENT_SCHEDULE_IMAGE_HOUR = 13
 
+# Every tournament (any type) is expected to be completed by this day/hour, independent of
+# training time, GPU availability, and round reverts during the week. Completion is a manual
+# step (see advance_tournament's "update DB manually" note), so this deadline only drives the
+# Discord reminder below - it never forces a tournament to finish.
+TOURNAMENT_DEADLINE_DAY_OF_WEEK = 4  # Friday
+TOURNAMENT_DEADLINE_HOUR = 14
+TOURNAMENT_DEADLINE_ALERT_MINUTES_BEFORE = 30
+
 # Tournament start requirements
 MIN_MINERS_FOR_ENV_TOURN = 5
 MIN_MINERS_FOR_TOURN = 4  # within the small-tournament band (3..9): round 1 is a single group, top 2 advance

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -115,6 +115,9 @@ _EMPTY_SCORE_ROUNDS_ALERTED: set[str] = set()
 # Rounds already pinged about a failed draw-decider creation. Same reason as the set above: the
 # retry runs on a 60s loop and would otherwise hammer the webhook until someone intervenes.
 _DECIDER_CREATION_FAILED_ROUNDS: set[str] = set()
+# Tournaments already pinged about being close to the Friday completion deadline. Process-local
+# for the same reason as the sets above: a restart re-alerts, which is fine for a once-a-week ping.
+_DEADLINE_ALERTED_TOURNAMENTS: set[str] = set()
 
 
 def exceeds_failure_threshold(trainings: dict[str, str]) -> bool:
@@ -1361,6 +1364,32 @@ async def process_pending_rounds(config: Config):
             await asyncio.sleep(t_cst.TOURNAMENT_PENDING_ROUND_CYCLE_INTERVAL)
 
 
+async def _alert_if_near_weekly_deadline(tournament: TournamentData, config: Config) -> None:
+    """Ping Discord once if this tournament is still active within the alert window before the
+    Friday completion deadline (see TOURNAMENT_DEADLINE_* in constants.py).
+
+    Completion is a manual step, so this is a reminder only - it never forces a tournament to
+    finish, and it doesn't try to guess whether the deadline will actually be missed.
+    """
+    now = datetime.now(timezone.utc)
+    if now.weekday() != t_cst.TOURNAMENT_DEADLINE_DAY_OF_WEEK:
+        return
+    deadline = now.replace(hour=t_cst.TOURNAMENT_DEADLINE_HOUR, minute=0, second=0, microsecond=0)
+    alert_start = deadline - timedelta(minutes=t_cst.TOURNAMENT_DEADLINE_ALERT_MINUTES_BEFORE)
+    if not (alert_start <= now < deadline):
+        return
+
+    await _alert_once(
+        tournament.tournament_id,
+        _DEADLINE_ALERTED_TOURNAMENTS,
+        f"Tournament deadline approaching\n"
+        f"Tournament: {tournament.tournament_id} ({tournament.tournament_type.value})\n"
+        f"Still ACTIVE with under {t_cst.TOURNAMENT_DEADLINE_ALERT_MINUTES_BEFORE} minutes left before the "
+        f"{t_cst.TOURNAMENT_DEADLINE_HOUR}:00 UTC Friday deadline. If it's actually finished, complete it manually now.",
+        config,
+    )
+
+
 async def process_active_tournaments(config: Config):
     """
     Process all active tournaments by advancing them if needed.
@@ -1373,6 +1402,7 @@ async def process_active_tournaments(config: Config):
             for tournament in active_tournaments:
                 with LogContext(tournament_id=tournament.tournament_id):
                     logger.info(f"Processing active tournament {tournament.tournament_id}")
+                    await _alert_if_near_weekly_deadline(tournament, config)
                     rounds = await get_tournament_rounds(tournament.tournament_id, config.psql_db)
                     if not rounds:
                         logger.info(f"Tournament {tournament.tournament_id} has no rounds, creating first round...")


### PR DESCRIPTION
## Summary
- Tournaments (env/text/image) are expected to complete by **Friday 14:00 UTC** of the week they started, regardless of training time, GPU availability, or a round being reverted mid-week.
- Documents that completion is a manual step: the team reviews the winning submission's code for exploits and confirms it reflects a genuine training improvement before marking the tournament complete.
- Adds a Discord reminder (via the existing `_alert_once`/`_notify_discord` mechanism) 30 minutes before the Friday 14:00 UTC cutoff for any tournament still active at that point, so the manual review/completion step doesn't slip past the deadline.

This is a reminder only — it does not force-complete tournaments; the actual completion flip is already a deliberate manual DB step elsewhere in the code.

## Test plan
- [x] `python -m ast` syntax check on `validator/tournament/constants.py` and `validator/tournament/tournament_manager.py`
- [x] Pre-commit hooks (ruff, codespell, etc.) passed on commit
- [ ] Manually verify the Discord reminder fires as expected in a staging/test environment around the Friday 13:30–14:00 UTC window

🤖 Generated with [Claude Code](https://claude.com/claude-code)