### PR TITLE
Implement backfill tools for tournament placements

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -490,7 +490,8 @@ Champions can earn boosted tournament allocation when boss-round performance exc
 A tournament pays a 3rd place only when it can be identified unambiguously:
 
 - **Text/Image**: the loser of the last single-pair knockout round before the boss round.
-- **Environment**: the single best-scoring non-boss, non-challenger miner across every group in the pre-boss round (valid since a round's groups all share the same model, environments, and eval seed).
+- **Environment (normal boss round)**: the single best-scoring non-boss, non-challenger miner across every group in the pre-boss round (valid since a round's groups all share the same model, environments, and eval seed).
+- **Environment (boss retains in the final group round)**: when the boss beats every co-group challenger and no single-challenger boss round is created, the top two non-boss challengers of that retention round are paid 2nd and 3rd by score (higher is better). A tie at the top omits both; a tie at the 3rd-place cutoff omits only 3rd.
 
 If no valid 3rd place exists (missing pre-boss round, a tie at the cutoff, or another degenerate case), the tournament pays only the top two ranks, renormalized.
 

--- a/ops/tools/tournament/README.md
+++ b/ops/tools/tournament/README.md
@@ -4,6 +4,8 @@ Manual tournament control and inspection tools.
 
 ## Contents
 
+- `backfill_boss_retention_placements.py`: backfill 2nd/3rd placements for environment tournaments that ended via boss retention with no `final_position` rows.
+- `backfill_third_place.py`: backfill missing 3rd-place placements on tournaments that already have positions 1 and 2.
 - `complete_tournament.py`: manually complete a tournament.
 - `environment_tournament_flow_probe.py`: end-to-end environment tournament flow probe.
 - `manage_tournament_task.py`: manage tournament task state.

--- a/ops/tools/tournament/backfill_boss_retention_placements.py
+++ b/ops/tools/tournament/backfill_boss_retention_placements.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Backfill 2nd/3rd placements for environment tournaments that ended via boss retention.
+
+Why this exists
+---------------
+When an environment round yields no winners (the boss beat every co-group challenger),
+``advance_tournament`` used to set ``winner_hotkey = EMISSION_BURN_HOTKEY`` and return
+without writing ``final_position`` for 2nd/3rd. Weight setting then paid the champion
+100% of the environment pool.
+
+The runtime fix now ranks non-boss challengers of the retention round and persists
+placements via ``update_tournament_placements``. This tool re-runs that ranking for
+already-completed tournaments that still have all ``final_position`` values NULL.
+
+Usage
+-----
+    # Dry run (default) for the known affected tournaments.
+    python ops/tools/tournament/backfill_boss_retention_placements.py
+
+    # Dry run for specific tournament ids.
+    python ops/tools/tournament/backfill_boss_retention_placements.py tourn_4f605297e6d85428_20260907
+
+    # Actually write the recomputed placements to the DB.
+    python ops/tools/tournament/backfill_boss_retention_placements.py --apply
+
+Reads DATABASE_URL from .vali.env. Does not touch the chain or upload anything.
+"""
+
+import argparse
+import asyncio
+
+from dotenv import load_dotenv
+
+from core.logging import get_logger
+from validator.db.database import PSQLDB
+from validator.db.sql.tournaments import get_tournament
+from validator.db.sql.tournaments import get_tournament_participants
+from validator.db.sql.tournaments import get_tournament_rounds
+from validator.db.sql.tournaments import update_tournament_placements
+from validator.scoring.constants import EMISSION_BURN_HOTKEY
+from validator.tournament.models import TournamentType
+from validator.tournament.round_results import get_boss_retention_runners_up
+
+
+logger = get_logger(__name__)
+
+# Confirmed affected: boss retained with empty winners, no final_positions written.
+DEFAULT_TOURNAMENT_IDS = (
+    "tourn_4f605297e6d85428_20260907",
+    "tourn_1e08b0b313ccc59f_20260817",
+)
+
+
+def _short(hotkey: str | None) -> str:
+    if not hotkey:
+        return "None"
+    return f"{hotkey[:8]}..."
+
+
+async def backfill_tournament(tournament_id: str, apply: bool, psql_db: PSQLDB) -> None:
+    tournament = await get_tournament(tournament_id, psql_db)
+    if not tournament:
+        logger.error(f"[{tournament_id}] not found; skipping")
+        return
+
+    print(f"\n=== {tournament.tournament_type.value.upper()}  {tournament_id} ===")
+    print(f"  winner_hotkey:      {_short(tournament.winner_hotkey)}")
+    print(f"  base_winner_hotkey: {_short(tournament.base_winner_hotkey)}")
+
+    if tournament.tournament_type != TournamentType.ENVIRONMENT:
+        logger.warning(f"[{tournament_id}] not an environment tournament; skipping")
+        return
+
+    if tournament.winner_hotkey != EMISSION_BURN_HOTKEY:
+        logger.warning(
+            f"[{tournament_id}] winner_hotkey is not EMISSION_BURN_HOTKEY "
+            f"({_short(tournament.winner_hotkey)}); skipping"
+        )
+        return
+
+    participants = await get_tournament_participants(tournament_id, psql_db)
+    placed = [p for p in participants if p.final_position is not None]
+    if placed:
+        by_position = {p.final_position: p.hotkey for p in placed}
+        print(
+            f"  -> placements already present "
+            f"(1={_short(by_position.get(1))}, 2={_short(by_position.get(2))}, "
+            f"3={_short(by_position.get(3))}); nothing to backfill"
+        )
+        return
+
+    rounds = await get_tournament_rounds(tournament_id, psql_db)
+    if not rounds:
+        logger.warning(f"[{tournament_id}] no rounds found; skipping")
+        return
+
+    retention_round = max(rounds, key=lambda r: r.round_number)
+    print(
+        f"  retention round: {retention_round.round_id} "
+        f"(round_number={retention_round.round_number}, is_final={retention_round.is_final_round})"
+    )
+
+    second_place, third_place = await get_boss_retention_runners_up(retention_round, psql_db)
+    print(f"  -> resolved position 2: {_short(second_place)}")
+    print(f"  -> resolved position 3: {_short(third_place)}")
+
+    if second_place is None:
+        print("  -> no clean 2nd place resolvable; leaving placements unchanged")
+        return
+
+    if not apply:
+        print("  (dry run: pass --apply to write this to the DB)")
+        return
+
+    await update_tournament_placements(
+        tournament_id,
+        EMISSION_BURN_HOTKEY,
+        second_place,
+        third_place,
+        psql_db,
+    )
+    print(
+        f"  APPLIED: final_position written "
+        f"(1={_short(EMISSION_BURN_HOTKEY)}, 2={_short(second_place)}, 3={_short(third_place)})"
+    )
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill 2nd/3rd placements for environment boss-retention completions."
+    )
+    parser.add_argument(
+        "tournament_ids",
+        nargs="*",
+        help=(
+            "Specific tournament ids. Defaults to the known affected boss-retention "
+            "tournaments (20260907 and 20260817)."
+        ),
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write recomputed placements to the DB (default is a dry run).",
+    )
+    args = parser.parse_args()
+
+    load_dotenv(".vali.env")
+
+    psql_db = PSQLDB()
+    await psql_db.connect()
+    try:
+        tournament_ids = args.tournament_ids or list(DEFAULT_TOURNAMENT_IDS)
+
+        if not args.apply:
+            print("DRY RUN - no database writes. Re-run with --apply to persist.")
+
+        for tournament_id in tournament_ids:
+            await backfill_tournament(tournament_id, args.apply, psql_db)
+    finally:
+        await psql_db.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ops/tools/tournament/backfill_third_place.py
+++ b/ops/tools/tournament/backfill_third_place.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Backfill 3rd-place (final_position = 3) for already-completed tournaments.
+
+Why this exists
+---------------
+Until the fix in #1364, ``get_pre_boss_knockout_loser`` read the always-NULL
+``tournament_pairs.winner_hotkey`` column, so its first guard tripped on every
+real tournament and finalization silently fell back to a top-2-only payout. Any
+tournament that finalized before that fix has its ``final_position`` frozen in the
+DB with no 3rd place, and the weight/audit path only *reads* those stored
+positions - so re-deploying the fix does not change emissions for those cohorts.
+
+This tool re-runs the (now fixed) 3rd-place resolution against the boss-round data
+and rewrites placements via ``update_tournament_placements``, preserving the
+existing winner (position 1) and runner-up (position 2). It is a no-op for any
+tournament whose 3rd place cannot be cleanly resolved.
+
+Usage
+-----
+    # Dry run (default): show what would change for the latest completed
+    # text/image/environment tournaments, write nothing.
+    python ops/tools/tournament/backfill_third_place.py
+
+    # Dry run for specific tournament ids.
+    python ops/tools/tournament/backfill_third_place.py tourn_add1dc83b8fd58b0_20260831
+
+    # Actually write the recomputed 3rd place to the DB.
+    python ops/tools/tournament/backfill_third_place.py --apply
+
+Reads DATABASE_URL from .vali.env. Does not touch the chain or upload anything.
+"""
+
+import argparse
+import asyncio
+
+from dotenv import load_dotenv
+
+from core.logging import get_logger
+from validator.db.database import PSQLDB
+from validator.db.sql.tournaments import get_latest_completed_tournament
+from validator.db.sql.tournaments import get_tournament
+from validator.db.sql.tournaments import get_tournament_participants
+from validator.db.sql.tournaments import get_tournament_rounds
+from validator.db.sql.tournaments import update_tournament_placements
+from validator.tournament.models import TournamentData
+from validator.tournament.models import TournamentRoundData
+from validator.tournament.models import TournamentType
+from validator.tournament.participants import get_pre_boss_knockout_loser
+from validator.tournament.round_results import get_pre_boss_group_runner_up
+
+
+logger = get_logger(__name__)
+
+
+def _short(hotkey: str | None) -> str:
+    if not hotkey:
+        return "None"
+    return f"{hotkey[:8]}..."
+
+
+def _final_round(rounds: list[TournamentRoundData]) -> TournamentRoundData | None:
+    final = next((r for r in rounds if r.is_final_round), None)
+    if final is not None:
+        return final
+    return max(rounds, key=lambda r: r.round_number) if rounds else None
+
+
+async def _resolve_third_place(
+    tournament: TournamentData,
+    final_round: TournamentRoundData,
+    challenger_hotkey: str,
+    psql_db: PSQLDB,
+) -> str | None:
+    if tournament.tournament_type in (TournamentType.TEXT, TournamentType.IMAGE):
+        return await get_pre_boss_knockout_loser(tournament, final_round, challenger_hotkey, psql_db)
+    if tournament.tournament_type == TournamentType.ENVIRONMENT:
+        return await get_pre_boss_group_runner_up(
+            tournament.tournament_id, final_round, challenger_hotkey, psql_db
+        )
+    return None
+
+
+async def backfill_tournament(tournament_id: str, apply: bool, psql_db: PSQLDB) -> None:
+    tournament = await get_tournament(tournament_id, psql_db)
+    if not tournament:
+        logger.error(f"[{tournament_id}] not found; skipping")
+        return
+
+    print(f"\n=== {tournament.tournament_type.value.upper()}  {tournament_id} ===")
+
+    participants = await get_tournament_participants(tournament_id, psql_db)
+    by_position = {p.final_position: p.hotkey for p in participants if p.final_position is not None}
+    winner = by_position.get(1)
+    second_place = by_position.get(2)
+    existing_third = by_position.get(3)
+
+    print(f"  current position 1 (winner):     {_short(winner)}")
+    print(f"  current position 2 (runner-up):  {_short(second_place)}")
+    print(f"  current position 3 (3rd place):  {_short(existing_third)}")
+
+    if winner is None or second_place is None:
+        logger.warning(
+            f"[{tournament_id}] missing position 1 and/or 2; refusing to rewrite placements"
+        )
+        return
+
+    if existing_third is not None:
+        print("  -> 3rd place already persisted; nothing to backfill")
+        return
+
+    rounds = await get_tournament_rounds(tournament_id, psql_db)
+    final_round = _final_round(rounds)
+    if final_round is None:
+        logger.warning(f"[{tournament_id}] no rounds found; skipping")
+        return
+
+    # The boss-round challenger (the miner that fought through to the final) is the
+    # persisted runner-up. The 3rd-place resolvers exclude this hotkey by design.
+    third_place = await _resolve_third_place(tournament, final_round, second_place, psql_db)
+
+    if third_place is not None and third_place in {winner, second_place}:
+        logger.warning(
+            f"[{tournament_id}] resolved 3rd place {_short(third_place)} collides with "
+            f"winner/runner-up; omitting"
+        )
+        third_place = None
+
+    if third_place is None:
+        print("  -> no clean 3rd place resolvable; leaving placements unchanged")
+        return
+
+    print(f"  -> resolved NEW position 3:      {_short(third_place)}  ({third_place})")
+
+    if not apply:
+        print("  (dry run: pass --apply to write this to the DB)")
+        return
+
+    await update_tournament_placements(
+        tournament_id,
+        winner,
+        second_place,
+        third_place,
+        psql_db,
+    )
+    print("  APPLIED: final_position=3 written")
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Backfill tournament 3rd place placements.")
+    parser.add_argument(
+        "tournament_ids",
+        nargs="*",
+        help="Specific tournament ids. Defaults to the latest completed text/image/environment tournaments.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write recomputed 3rd place to the DB (default is a dry run).",
+    )
+    args = parser.parse_args()
+
+    load_dotenv(".vali.env")
+
+    psql_db = PSQLDB()
+    await psql_db.connect()
+    try:
+        tournament_ids = args.tournament_ids
+        if not tournament_ids:
+            tournament_ids = []
+            for tournament_type in (TournamentType.TEXT, TournamentType.IMAGE, TournamentType.ENVIRONMENT):
+                latest = await get_latest_completed_tournament(psql_db, tournament_type)
+                if latest:
+                    tournament_ids.append(latest.tournament_id)
+                else:
+                    logger.warning(f"No completed {tournament_type.value} tournament found")
+
+        if not args.apply:
+            print("DRY RUN - no database writes. Re-run with --apply to persist.")
+
+        for tournament_id in tournament_ids:
+            await backfill_tournament(tournament_id, args.apply, psql_db)
+    finally:
+        await psql_db.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ops/tools/tournament/re_evaluate_tournament_group_task.py
+++ b/ops/tools/tournament/re_evaluate_tournament_group_task.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Reset a completed tournament group task for partial retrain + full re-eval.
+
+Use when a group task finished with unfair training failures (e.g. orchestrator/trainer
+desync) but the round already advanced. This tool:
+
+  reset               — Step 1: reset selected hotkeys to pending, wipe stale eval artifacts,
+                        set task back to training so orchestrator + eval loops re-run.
+  show-winner         — Step 3: print group winner from task_nodes.quality_score after re-eval.
+  swap-round3-contender — Step 4: replace one round-3 finalist if the group winner changed.
+
+Round-2 advancement is NOT re-triggered automatically once round 3 exists; use swap-round3-
+contender when the corrected group winner differs from who advanced.
+
+Examples:
+
+    python -m ops.tools.tournament.re_evaluate_tournament_group_task reset \\
+        --task-id 2f4d34af-f494-4128-8117-fa7fce4a5c99 \\
+        --retrain-hotkeys 5EqKHiZG...,5HKEAZ...,5EqnMmpf... \\
+        --dry-run
+
+    python -m ops.tools.tournament.re_evaluate_tournament_group_task show-winner \\
+        --task-id 2f4d34af-f494-4128-8117-fa7fce4a5c99
+
+    python -m ops.tools.tournament.re_evaluate_tournament_group_task swap-round3-contender \\
+        --tournament-id tourn_31f2e0fe36783f71_20260831 \\
+        --round3-group-id tourn_31f2e0fe36783f71_20260831_round_003_group_001 \\
+        --old-hotkey 5GU4Xkd3... --new-hotkey 5HKEAZxF... \\
+        --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from uuid import UUID
+
+import asyncpg
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.table import Table
+
+from core.constants.network import NETUID
+from validator.db import constants as cst
+
+
+console = Console()
+
+load_dotenv(".vali.env")
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+
+async def _connect() -> asyncpg.Connection:
+    if not DATABASE_URL:
+        raise RuntimeError("DATABASE_URL not set (source .vali.env)")
+    return await asyncpg.connect(DATABASE_URL)
+
+
+async def _get_task_hotkeys(conn: asyncpg.Connection, task_id: str) -> list[str]:
+    rows = await conn.fetch(
+        f"""
+        SELECT {cst.HOTKEY} FROM {cst.TOURNAMENT_TASK_HOTKEY_TRAININGS_TABLE}
+        WHERE {cst.TASK_ID} = $1 ORDER BY {cst.HOTKEY}
+        """,
+        task_id,
+    )
+    return [row[cst.HOTKEY] for row in rows]
+
+
+async def cmd_reset(args: argparse.Namespace) -> None:
+    task_id = args.task_id
+    UUID(task_id)
+    retrain_hotkeys = [hk.strip() for hk in args.retrain_hotkeys.split(",") if hk.strip()]
+
+    conn = await _connect()
+    try:
+        all_hotkeys = await _get_task_hotkeys(conn, task_id)
+        if not all_hotkeys:
+            console.print(f"No training rows for task {task_id}", style="red")
+            return
+
+        unknown = set(retrain_hotkeys) - set(all_hotkeys)
+        if unknown:
+            console.print(f"Hotkeys not on task: {unknown}", style="red")
+            return
+
+        keep_hotkeys = [hk for hk in all_hotkeys if hk not in retrain_hotkeys]
+        table = Table(title=f"Reset plan for task {task_id}")
+        table.add_column("hotkey", overflow="fold")
+        table.add_column("action")
+        for hk in retrain_hotkeys:
+            table.add_row(hk, "[yellow]retrain[/yellow] (pending, attempts=0, clear submission)")
+        for hk in keep_hotkeys:
+            table.add_row(hk, "[green]keep training status[/green]")
+        table.add_row("—", "delete pvp_pair_results + pvp_individual_scores")
+        table.add_row("—", "clear quality_score/test_loss/synth_loss for ALL hotkeys on task")
+        table.add_row("—", "reset evaluations to pending")
+        table.add_row("—", "set tasks.status = training")
+        console.print(table)
+
+        if args.dry_run:
+            console.print("Dry run — no changes applied.", style="cyan")
+            return
+
+        async with conn.transaction():
+            for hk in retrain_hotkeys:
+                await conn.execute(
+                    f"""
+                    UPDATE {cst.TOURNAMENT_TASK_HOTKEY_TRAININGS_TABLE}
+                    SET {cst.TRAINING_STATUS} = 'pending',
+                        {cst.N_TRAINING_ATTEMPTS} = 0,
+                        {cst.TRAINER_IP} = NULL,
+                        {cst.UPDATED_AT} = CURRENT_TIMESTAMP
+                    WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2
+                    """,
+                    task_id,
+                    hk,
+                )
+                await conn.execute(
+                    f"DELETE FROM {cst.SUBMISSIONS_TABLE} WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2",
+                    task_id,
+                    hk,
+                )
+
+            await conn.execute(
+                f"DELETE FROM {cst.PVP_PAIR_RESULTS_TABLE} WHERE {cst.TASK_ID} = $1", task_id
+            )
+            await conn.execute(
+                f"DELETE FROM {cst.PVP_INDIVIDUAL_SCORES_TABLE} WHERE {cst.TASK_ID} = $1", task_id
+            )
+            await conn.execute(
+                f"""
+                UPDATE {cst.TASK_NODES_TABLE}
+                SET {cst.TASK_NODE_QUALITY_SCORE} = NULL,
+                    {cst.TEST_LOSS} = NULL,
+                    {cst.SYNTH_LOSS} = NULL
+                WHERE {cst.TASK_ID} = $1
+                """,
+                task_id,
+            )
+            await conn.execute(
+                f"""
+                UPDATE {cst.EVALUATIONS_TABLE}
+                SET {cst.EVALUATION_STATUS} = 'pending',
+                    {cst.UPDATED_AT} = CURRENT_TIMESTAMP
+                WHERE {cst.TASK_ID} = $1 AND {cst.NETUID} = $2
+                """,
+                task_id,
+                NETUID,
+            )
+            await conn.execute(
+                f"""
+                UPDATE {cst.TASKS_TABLE}
+                SET {cst.STATUS} = 'training', {cst.UPDATED_AT} = CURRENT_TIMESTAMP
+                WHERE {cst.TASK_ID} = $1
+                """,
+                task_id,
+            )
+
+        console.print(f"Reset complete for task {task_id}. Orchestrator will retrain pending hotkeys.", style="green")
+    finally:
+        await conn.close()
+
+
+async def cmd_show_winner(args: argparse.Namespace) -> None:
+    task_id = args.task_id
+    conn = await _connect()
+    try:
+        rows = await conn.fetch(
+            f"""
+            SELECT {cst.HOTKEY}, {cst.TASK_NODE_QUALITY_SCORE}, {cst.TEST_LOSS}, {cst.SYNTH_LOSS}
+            FROM {cst.TASK_NODES_TABLE}
+            WHERE {cst.TASK_ID} = $1
+            ORDER BY {cst.TASK_NODE_QUALITY_SCORE} DESC NULLS LAST, {cst.HOTKEY}
+            """,
+            task_id,
+        )
+        table = Table(title=f"Scores for task {task_id}")
+        table.add_column("hotkey", overflow="fold")
+        table.add_column("quality_score")
+        table.add_column("test_loss")
+        table.add_column("synth_loss")
+        winner = None
+        best_score = None
+        for row in rows:
+            qs = row[cst.TASK_NODE_QUALITY_SCORE]
+            table.add_row(row[cst.HOTKEY], str(qs), str(row[cst.TEST_LOSS]), str(row[cst.SYNTH_LOSS]))
+            if qs is not None and (best_score is None or qs > best_score):
+                best_score = qs
+                winner = row[cst.HOTKEY]
+        console.print(table)
+        if winner:
+            console.print(f"Group winner (highest quality_score): {winner}", style="bold green")
+        else:
+            console.print("No scored winner yet — wait for re-eval to finish.", style="yellow")
+    finally:
+        await conn.close()
+
+
+async def cmd_swap_round3_contender(args: argparse.Namespace) -> None:
+    tournament_id = args.tournament_id
+    round3_group_id = args.round3_group_id
+    old_hotkey = args.old_hotkey
+    new_hotkey = args.new_hotkey
+    round2_id = args.round2_id or f"{tournament_id}_round_002"
+
+    conn = await _connect()
+    try:
+        r3_tasks = await conn.fetch(
+            f"""
+            SELECT t.{cst.TASK_ID}::text
+            FROM {cst.TOURNAMENT_TASKS_TABLE} tt
+            JOIN {cst.TASKS_TABLE} t ON t.{cst.TASK_ID} = tt.{cst.TASK_ID}
+            WHERE tt.{cst.GROUP_ID} = $1
+            ORDER BY t.{cst.CREATED_AT}
+            """,
+            round3_group_id,
+        )
+        if not r3_tasks:
+            console.print(f"No round-3 tasks for group {round3_group_id}", style="red")
+            return
+
+        task_ids = [row[cst.TASK_ID] for row in r3_tasks]
+        table = Table(title="Round 3 contender swap plan")
+        table.add_column("step")
+        table.add_column("detail", overflow="fold")
+        table.add_row("participants", f"clear eliminated_in_round_id for {new_hotkey}")
+        table.add_row("participants", f"set eliminated_in_round_id={round2_id} for {old_hotkey}")
+        table.add_row("group members", f"replace {old_hotkey} -> {new_hotkey} in {round3_group_id}")
+        for tid in task_ids:
+            table.add_row("task_nodes", f"reassign {tid} node from {old_hotkey} to {new_hotkey}")
+            table.add_row("trainings", f"reset {new_hotkey} on {tid} to pending; leave {old_hotkey} orphaned")
+        console.print(table)
+
+        if args.dry_run:
+            console.print("Dry run — no changes applied.", style="cyan")
+            return
+
+        async with conn.transaction():
+            await conn.execute(
+                f"""
+                UPDATE {cst.TOURNAMENT_PARTICIPANTS_TABLE}
+                SET {cst.ELIMINATED_IN_ROUND_ID} = NULL
+                WHERE {cst.TOURNAMENT_ID} = $1 AND {cst.HOTKEY} = $2
+                """,
+                tournament_id,
+                new_hotkey,
+            )
+            await conn.execute(
+                f"""
+                UPDATE {cst.TOURNAMENT_PARTICIPANTS_TABLE}
+                SET {cst.ELIMINATED_IN_ROUND_ID} = $2
+                WHERE {cst.TOURNAMENT_ID} = $1 AND {cst.HOTKEY} = $3
+                """,
+                tournament_id,
+                round2_id,
+                old_hotkey,
+            )
+            await conn.execute(
+                f"""
+                UPDATE {cst.TOURNAMENT_GROUP_MEMBERS_TABLE}
+                SET {cst.HOTKEY} = $3
+                WHERE {cst.GROUP_ID} = $1 AND {cst.HOTKEY} = $2
+                """,
+                round3_group_id,
+                old_hotkey,
+                new_hotkey,
+            )
+
+            for tid in task_ids:
+                old_node = await conn.fetchrow(
+                    f"""
+                    SELECT {cst.EXPECTED_REPO_NAME}, {cst.NODE_ID}
+                    FROM {cst.TASK_NODES_TABLE}
+                    WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2
+                    """,
+                    tid,
+                    old_hotkey,
+                )
+                if not old_node:
+                    console.print(f"No task_node for {old_hotkey} on {tid}", style="red")
+                    raise RuntimeError("missing old task_node")
+
+                new_repo = await conn.fetchval(
+                    f"""
+                    SELECT {cst.EXPECTED_REPO_NAME}
+                    FROM {cst.TASK_NODES_TABLE}
+                    WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2
+                    """,
+                    args.r2_task_id,
+                    new_hotkey,
+                )
+                if not new_repo:
+                    console.print(
+                        f"No R2 expected_repo_name for {new_hotkey} on {args.r2_task_id}", style="red"
+                    )
+                    raise RuntimeError("missing new winner repo from R2 task")
+
+                existing_new = await conn.fetchval(
+                    f"""
+                    SELECT 1 FROM {cst.TASK_NODES_TABLE}
+                    WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2
+                    """,
+                    tid,
+                    new_hotkey,
+                )
+                if existing_new:
+                    await conn.execute(
+                        f"""
+                        UPDATE {cst.TASK_NODES_TABLE}
+                        SET {cst.EXPECTED_REPO_NAME} = $3,
+                            {cst.TASK_NODE_QUALITY_SCORE} = NULL,
+                            {cst.TEST_LOSS} = NULL,
+                            {cst.SYNTH_LOSS} = NULL,
+                            {cst.UPDATED_AT} = CURRENT_TIMESTAMP
+                        WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2
+                        """,
+                        tid,
+                        new_hotkey,
+                        new_repo,
+                    )
+                else:
+                    await conn.execute(
+                        f"""
+                        UPDATE {cst.TASK_NODES_TABLE}
+                        SET {cst.HOTKEY} = $3,
+                            {cst.EXPECTED_REPO_NAME} = $4,
+                            {cst.TASK_NODE_QUALITY_SCORE} = NULL,
+                            {cst.TEST_LOSS} = NULL,
+                            {cst.SYNTH_LOSS} = NULL,
+                            {cst.UPDATED_AT} = CURRENT_TIMESTAMP
+                        WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2
+                        """,
+                        tid,
+                        old_hotkey,
+                        new_hotkey,
+                        new_repo,
+                    )
+
+                await conn.execute(
+                    f"""
+                    UPDATE {cst.TOURNAMENT_TASK_HOTKEY_TRAININGS_TABLE}
+                    SET {cst.TRAINING_STATUS} = 'pending',
+                        {cst.N_TRAINING_ATTEMPTS} = 0,
+                        {cst.TRAINER_IP} = NULL,
+                        {cst.UPDATED_AT} = CURRENT_TIMESTAMP
+                    WHERE {cst.TASK_ID} = $1 AND {cst.HOTKEY} = $2
+                    """,
+                    tid,
+                    new_hotkey,
+                )
+
+                task_status = await conn.fetchval(
+                    f"SELECT {cst.STATUS} FROM {cst.TASKS_TABLE} WHERE {cst.TASK_ID} = $1", tid
+                )
+                if task_status == "success":
+                    await conn.execute(
+                        f"""
+                        UPDATE {cst.TASKS_TABLE}
+                        SET {cst.STATUS} = 'training', {cst.UPDATED_AT} = CURRENT_TIMESTAMP
+                        WHERE {cst.TASK_ID} = $1
+                        """,
+                        tid,
+                    )
+
+        console.print("Round 3 contender swap complete.", style="green")
+    finally:
+        await conn.close()
+
+
+def _add_dry_run(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply changes (default is dry-run)",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    reset_p = sub.add_parser("reset", help="Reset task for partial retrain + full re-eval")
+    reset_p.add_argument("--task-id", required=True)
+    reset_p.add_argument(
+        "--retrain-hotkeys",
+        required=True,
+        help="Comma-separated hotkeys to reset to pending (others keep current training status)",
+    )
+    _add_dry_run(reset_p)
+
+    show_p = sub.add_parser("show-winner", help="Show group winner from quality_score")
+    show_p.add_argument("--task-id", required=True)
+
+    swap_p = sub.add_parser("swap-round3-contender", help="Replace round-3 finalist after corrected R2 winner")
+    swap_p.add_argument("--tournament-id", required=True)
+    swap_p.add_argument("--round3-group-id", required=True)
+    swap_p.add_argument("--old-hotkey", required=True, help="Hotkey currently in round 3 (incorrect advancer)")
+    swap_p.add_argument("--new-hotkey", required=True, help="Corrected group winner from R2 re-eval")
+    swap_p.add_argument(
+        "--r2-task-id",
+        required=True,
+        help="Round-2 group task id (source of new winner expected_repo_name)",
+    )
+    swap_p.add_argument(
+        "--round2-id",
+        help="Round id for eliminating old contender (default: {tournament_id}_round_002)",
+    )
+    _add_dry_run(swap_p)
+
+    args = parser.parse_args()
+    args.dry_run = not getattr(args, "apply", False)
+
+    if args.command == "reset":
+        asyncio.run(cmd_reset(args))
+    elif args.command == "show-winner":
+        asyncio.run(cmd_show_winner(args))
+    elif args.command == "swap-round3-contender":
+        asyncio.run(cmd_swap_round3_contender(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/validator/tournament/round_results.py
+++ b/validator/tournament/round_results.py
@@ -998,6 +998,69 @@ async def get_pre_boss_group_runner_up(
     return runner_up_hotkey
 
 
+async def get_boss_retention_runners_up(
+    completed_round: TournamentRoundData,
+    psql_db: PSQLDB,
+) -> tuple[str | None, str | None]:
+    """Rank non-boss challengers of a boss-retention round for 2nd/3rd place.
+
+    Used when an environment round yields no winners because the boss beat every
+    co-group challenger (and no other group advanced anyone). Champion stays 1st;
+    the best non-boss score in this round is 2nd, the next is 3rd.
+
+    Returns ``(second, third)``. Either may be None when no clean unique placement
+    exists: no valid challenger scores, a tie at the top (ambiguous 2nd), or a tie
+    at the 3rd-place cutoff (omit 3rd only). Scores are comparable across groups in
+    the same round (shared model, environments, and eval seed).
+    """
+    boss_hotkey = EMISSION_BURN_HOTKEY
+    round_tasks = await get_tournament_tasks(completed_round.round_id, psql_db)
+    if not round_tasks:
+        return (None, None)
+
+    candidates: list[tuple[str, float]] = []
+    for task in round_tasks:
+        miner_results = await get_task_results_for_ranking(task.task_id, psql_db)
+        if not miner_results:
+            continue
+        for result in calculate_miner_ranking_and_scores(miner_results):
+            if result.hotkey == boss_hotkey:
+                continue
+            if result.adjusted_loss is None or np.isnan(result.adjusted_loss):
+                continue
+            candidates.append((result.hotkey, result.adjusted_loss))
+
+    if not candidates:
+        return (None, None)
+
+    candidates.sort(key=lambda item: item[1], reverse=True)
+
+    # Tie at the top: cannot identify a unique 2nd place.
+    if len(candidates) > 1 and candidates[0][1] == candidates[1][1]:
+        logger.info(
+            f"Boss-retention round {completed_round.round_id}: top challengers tied at "
+            f"{candidates[0][1]}; omitting 2nd/3rd placements"
+        )
+        return (None, None)
+
+    second = candidates[0][0]
+    third: str | None = None
+    if len(candidates) >= 2:
+        # Tie at the 3rd-place cutoff: omit 3rd rather than guess.
+        if len(candidates) >= 3 and candidates[1][1] == candidates[2][1]:
+            logger.info(
+                f"Boss-retention round {completed_round.round_id}: 3rd-place cutoff tied at "
+                f"{candidates[1][1]}; paying 2nd={second} only"
+            )
+        else:
+            third = candidates[1][0]
+
+    logger.info(
+        f"Boss-retention round {completed_round.round_id}: placements second={second}, third={third}"
+    )
+    return (second, third)
+
+
 async def _get_small_tournament_group_winners(round_tasks: list[TournamentTask], psql_db: PSQLDB) -> list[str]:
     """Rank competitors across the multi-match small-tournament group."""
     match_rankings: list[MatchRanking] = []

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -98,6 +98,7 @@ from validator.tournament.repo_uploader import upload_tournament_participant_rep
 from validator.tournament.reports import generate_diff_report_and_notify_tournament_completed
 from validator.tournament.round_results import determine_env_tournament_winner
 from validator.tournament.round_results import find_groups_with_no_valid_scores
+from validator.tournament.round_results import get_boss_retention_runners_up
 from validator.tournament.round_results import get_pre_boss_group_runner_up
 from validator.tournament.round_results import get_round_winners
 from validator.tournament.task_creator import create_boss_round_decider_tasks
@@ -666,9 +667,26 @@ async def advance_tournament(tournament: TournamentData, completed_round: Tourna
             )
             # Keep EMISSION_BURN_HOTKEY as the winner when defending champion wins by default
             winner = EMISSION_BURN_HOTKEY
-            await update_tournament_winner_hotkey(tournament.tournament_id, winner, psql_db)
+            second_place: str | None = None
+            third_place: str | None = None
+            if tournament.tournament_type == TournamentType.ENVIRONMENT:
+                # Boss retained in this round: pay the top non-boss challengers of the
+                # retention round as 2nd/3rd so the environment pool is not 100% champion-only.
+                second_place, third_place = await get_boss_retention_runners_up(completed_round, psql_db)
+                await update_tournament_placements(
+                    tournament.tournament_id,
+                    winner,
+                    second_place,
+                    third_place,
+                    psql_db,
+                )
+            else:
+                await update_tournament_winner_hotkey(tournament.tournament_id, winner, psql_db)
             # await update_tournament_status(tournament.tournament_id, TournamentStatus.COMPLETED, psql_db)
-            logger.info(f"Tournament {tournament.tournament_id} completed with winner: {winner}. Please update DB manually.")
+            logger.info(
+                f"Tournament {tournament.tournament_id} completed with winner: {winner}, "
+                f"second={second_place}, third={third_place}. Please update DB manually."
+            )
 
             asyncio.create_task(
                 notify_tournament_completed(


### PR DESCRIPTION
- Added `backfill_boss_retention_placements.py` to backfill 2nd and 3rd placements for environment tournaments that ended without final positions due to boss retention.
- Introduced `backfill_third_place.py` to resolve and backfill missing 3rd-place placements for completed tournaments with known winners.
- Updated `README.md` to document the new backfill tools and their usage.
- Enhanced `round_results.py` with a new function to rank non-boss challengers in boss-retention rounds for accurate placement.
- Modified `tournament_manager.py` to utilize the new ranking function during tournament advancement for environment types.